### PR TITLE
Fixes check_time_until_logout bug in development mode

### DIFF
--- a/app/views/devise/sessions/session_expiration_warning.js.erb
+++ b/app/views/devise/sessions/session_expiration_warning.js.erb
@@ -35,5 +35,6 @@ $('#stay-logged-in').on('click', function() {
 
 });
 <% else %>
+<% @time_left = 10000 if Rails.env.development? %>
 setTimeout(check_time_until_logout, <%= (@time_left - 30) * 1000 %>);
 <% end %>


### PR DESCRIPTION
Not related to a ticket.

-- This is related - ironically - to setting the Devise.timeout_in to a very large number during initialization to keep the developer's session logged in.

window.setTimeout uses a 32bit integer to represent the timeout length in milliseconds. For very large numbers this will cause an uncaught error where it apparently just runs non-stop (or with a very very very small delay).

http://stackoverflow.com/questions/3468607/why-does-settimeout-break-for-large-millisecond-delay-values

My modification simply adjusts the timeout length response from devise inside the js.erb partial

### Master Redmine ticket
* (Required!)

### Child Redmine ticket(s)
* ()
* ()

### Local build result

```
bundle exec rake parallel:spec[4]
bundle exec cucumber
```

### Latest rebase/merge tag
*

---

### Data ticket(s) Followup
* (redmine links here - optional)

### Related Pull Requests
* (github links here - optional)

---

### TODOs / Notes
#### Peer Review
* (For code review)

#### Functional Testing
* (For testing locally)

#### Deployment
* (for release manager and/or build manager)
