### PR TITLE
SHOP QLE carousel for IVL

### DIFF
--- a/app/controllers/insured/families_controller.rb
+++ b/app/controllers/insured/families_controller.rb
@@ -280,15 +280,7 @@ class Insured::FamiliesController < FamiliesController
         @qualifying_life_events += QualifyingLifeEventKind.send @manually_picked_role if @manually_picked_role
       end
     else
-      if @person.active_employee_roles.present?
-        if current_user.has_hbx_staff_role?
-          @qualifying_life_events += QualifyingLifeEventKind.fetch_applicable_market_events_admin
-        else
-          @qualifying_life_events += QualifyingLifeEventKind.shop_market_events
-        end
-      else @person.consumer_role.present?
-        @qualifying_life_events += QualifyingLifeEventKind.shop_market_events
-      end
+      @qualifying_life_events += current_user.has_hbx_staff_role? ? QualifyingLifeEventKind.fetch_applicable_market_events_admin : QualifyingLifeEventKind.shop_market_events
     end
   end
 

--- a/app/controllers/insured/families_controller.rb
+++ b/app/controllers/insured/families_controller.rb
@@ -287,7 +287,7 @@ class Insured::FamiliesController < FamiliesController
           @qualifying_life_events += QualifyingLifeEventKind.shop_market_events
         end
       else @person.consumer_role.present?
-        @qualifying_life_events += QualifyingLifeEventKind.fetch_applicable_market_events_admin
+        @qualifying_life_events += QualifyingLifeEventKind.shop_market_events
       end
     end
   end

--- a/app/controllers/insured/families_controller.rb
+++ b/app/controllers/insured/families_controller.rb
@@ -287,11 +287,7 @@ class Insured::FamiliesController < FamiliesController
           @qualifying_life_events += QualifyingLifeEventKind.shop_market_events
         end
       else @person.consumer_role.present?
-        if current_user.has_hbx_staff_role?
-          @qualifying_life_events += QualifyingLifeEventKind.fetch_applicable_market_events_admin
-        else
-          @qualifying_life_events += QualifyingLifeEventKind.individual_market_events
-        end
+        @qualifying_life_events += QualifyingLifeEventKind.fetch_applicable_market_events_admin
       end
     end
   end


### PR DESCRIPTION
This PR  will address When families/home carousel will display shop QLE instead of IVL QLE

To test:
  1) add a "new" employee to employer 
  2) employee enroll should be able to see SHOP QLE alone 
  3) Terminate Employee 
  4) check the IVL QLE where you should see only SHOP QLE  