### PR TITLE
employee roster datatable last peice

### DIFF
--- a/app/assets/javascripts/employer_profile.js
+++ b/app/assets/javascripts/employer_profile.js
@@ -460,6 +460,11 @@ $(function() {
   })
 })
 
+$(document).on('click', "a.terminate.cancel", function(){
+    $('tr.child-row:visible').remove();
+    $("li>a:contains('Collapse Form')").addClass('disabled');
+});
+
 $(document).on('click', "a.interaction-click-control-terminate", function(){
   event.preventDefault();
   console.log('hey')


### PR DESCRIPTION
Look like terminate functionality view was properly removing child columns. 
This PR will fix the issue . 
to test : 
1) goto employer roster datatable
2) click terminate and from child row choose cancel 
3) view looks odd and not been removing child row.
this PR will fix the issue 