### PR TITLE
Metal level service area fix

### DIFF
--- a/app/controllers/employers/plan_years_controller.rb
+++ b/app/controllers/employers/plan_years_controller.rb
@@ -39,7 +39,8 @@ class Employers::PlanYearsController < ApplicationController
       Plan.by_active_year(params[:start_on]).for_service_areas(@employer_profile.service_area_ids).shop_market.health_coverage.by_carrier_profile(@carrier_profile).and(hios_id: /-01/)
     elsif params[:plan_option_kind] == "metal_level"
       @metal_level = params[:metal_level]
-      Plan.by_active_year(params[:start_on]).for_service_areas(@employer_profile.service_area_ids).shop_market.health_coverage.by_metal_level(@metal_level).and(hios_id: /-01/)
+      @available_carrier_ids = CarrierProfile.carriers_for(@employer_profile)
+      Plan.by_active_year(params[:start_on]).for_service_areas_and_carriers(@employer_profile.service_area_ids, @available_carrier_ids).shop_market.health_coverage.by_metal_level(@metal_level).and(hios_id: /-01/)
     elsif ["single_plan", "sole_source"].include?(params[:plan_option_kind])
       @single_plan = params[:single_plan]
       @carrier_id = params[:carrier_id]
@@ -184,7 +185,7 @@ class Employers::PlanYearsController < ApplicationController
     else
       @plan_year.benefit_groups[0].reference_plan = @plan
     end
-    @plan_year.benefit_groups[0].build_estimated_composite_rates
+    @plan_year.benefit_groups[0].build_estimated_composite_rates if @plan_option_kind == 'sole_source'
 
     @employer_contribution_amount = @plan_year.benefit_groups[0].monthly_employer_contribution_amount(@plan)
     @min_employee_cost = @plan_year.benefit_groups[0].monthly_min_employee_cost(coverage_type)

--- a/app/controllers/employers/plan_years_controller.rb
+++ b/app/controllers/employers/plan_years_controller.rb
@@ -39,8 +39,7 @@ class Employers::PlanYearsController < ApplicationController
       Plan.by_active_year(params[:start_on]).for_service_areas(@employer_profile.service_area_ids).shop_market.health_coverage.by_carrier_profile(@carrier_profile).and(hios_id: /-01/)
     elsif params[:plan_option_kind] == "metal_level"
       @metal_level = params[:metal_level]
-      @available_carrier_ids = CarrierProfile.carriers_for(@employer_profile)
-      Plan.by_active_year(params[:start_on]).for_service_areas_and_carriers(@employer_profile.service_area_ids, @available_carrier_ids).shop_market.health_coverage.by_metal_level(@metal_level).and(hios_id: /-01/)
+      Plan.by_active_year(params[:start_on]).for_service_areas_and_carriers(CarrierProfile.carrier_profile_service_area_pairs_for(@employer_profile), TimeKeeper.date_of_record.year).shop_market.health_coverage.by_metal_level(@metal_level).and(hios_id: /-01/)
     elsif ["single_plan", "sole_source"].include?(params[:plan_option_kind])
       @single_plan = params[:single_plan]
       @carrier_id = params[:carrier_id]
@@ -266,6 +265,7 @@ class Employers::PlanYearsController < ApplicationController
         benefit_group.elected_dental_plans_by_option_kind
       end
       benefit_group.elected_dental_plans = ax if ax
+      benefit_group.build_estimated_composite_rates
     end
 
     if @plan_year.save

--- a/app/models/carrier_profile.rb
+++ b/app/models/carrier_profile.rb
@@ -67,7 +67,7 @@ class CarrierProfile
 
     def carriers_for(employer_profile)
       servicing_hios_ids = employer_profile.service_areas.collect { |service_area| service_area.issuer_hios_id }.uniq
-      where(issuer_hios_id: servicing_hios_ids)
+      self.all.reject { |cp| (cp.issuer_hios_ids & servicing_hios_ids).empty? }
     end
 
     def first

--- a/app/models/carrier_profile.rb
+++ b/app/models/carrier_profile.rb
@@ -70,6 +70,19 @@ class CarrierProfile
       self.all.reject { |cp| (cp.issuer_hios_ids & servicing_hios_ids).empty? }
     end
 
+    def carrier_profile_service_area_pairs_for(employer_profile)
+     hios_carrier_id_mapping = Organization.where("carrier_profile" => {"$exists" => true}).inject({}) do |acc, org|
+       cp = org.carrier_profile
+       cp.issuer_hios_ids.each do |ihid|
+         acc[ihid] = cp.id
+       end
+       acc
+     end
+     employer_profile.service_areas.map do |service_area|
+       [hios_carrier_id_mapping[service_area.issuer_hios_id], service_area.service_area_id]
+     end.uniq
+   end
+
     def first
       all.first
     end

--- a/app/models/carrier_service_area.rb
+++ b/app/models/carrier_service_area.rb
@@ -28,10 +28,6 @@ class CarrierServiceArea
       return issuers.service_areas_for(office_location: office_location).any?
     end
 
-    def service_area_ids_for(office_location:)
-      where(service_area_zipcode: office_location.address.zip).pluck(:service_area_id) + serving_entire_state.pluck(:service_area_id)
-    end
-
     def service_areas_for(office_location:)
       address = office_location.address
       areas_valid_for_zip_code(zip_code: address.zip)

--- a/app/models/composite_rating_base_rates_calculator.rb
+++ b/app/models/composite_rating_base_rates_calculator.rb
@@ -7,7 +7,9 @@ class CompositeRatingBaseRatesCalculator
   end
 
   def base_rate
-    @base_rate ||= (create_numerator/create_denominator).round(2)
+    @denominator ||= create_denominator
+    return 0 if create_denominator == 0
+    @base_rate ||= (create_numerator/@denominator).round(2)
   end
 
   def tier_rates

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -174,7 +174,8 @@ class Plan
   scope :by_plan_type,          ->(plan_type) { where(plan_type: plan_type) }
   scope :by_dental_level_for_bqt,       ->(dental_level) { where(:dental_level.in => dental_level) }
   scope :by_plan_type_for_bqt,          ->(plan_type) { where(:plan_type.in => plan_type) }
-  scope :for_service_areas,         ->(service_areas) { where(service_area_id: { "$in" => service_areas }) }
+  scope :for_service_areas_and_carriers,->(service_areas, carrier_profile_ids) { where(service_area_id: { "$in" => service_areas }, carrier_profile_id: { "$in" => carrier_profile_ids}) }
+  scope :for_service_areas,             ->(service_areas) { where(service_area_id: { "$in" => service_areas }) }
 
   # Marketplace
   scope :shop_market,           ->{ where(market: "shop") }

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -174,7 +174,7 @@ class Plan
   scope :by_plan_type,          ->(plan_type) { where(plan_type: plan_type) }
   scope :by_dental_level_for_bqt,       ->(dental_level) { where(:dental_level.in => dental_level) }
   scope :by_plan_type_for_bqt,          ->(plan_type) { where(:plan_type.in => plan_type) }
-  scope :for_service_areas_and_carriers,->(service_areas, carrier_profile_ids) { where(service_area_id: { "$in" => service_areas }, carrier_profile_id: { "$in" => carrier_profile_ids}) }
+  #scope :for_service_areas_and_carriers,->(service_areas, carrier_profile_ids) { where(service_area_id: { "$in" => service_areas }, carrier_profile_id: { "$in" => carrier_profile_ids}) }
   scope :for_service_areas,             ->(service_areas) { where(service_area_id: { "$in" => service_areas }) }
 
   # Marketplace
@@ -292,6 +292,17 @@ class Plan
   # Carriers: use class method (which may be chained)
   def self.find_by_carrier_profile(carrier_profile)
     where(carrier_profile_id: carrier_profile._id)
+  end
+
+  def self.for_service_areas_and_carriers(service_area_carrier_pairs, active_year)
+    plan_criteria_set = service_area_carrier_pairs.map do |sap|
+    	{
+    		:carrier_profile_id => sap.first,
+    		:service_area_id => sap.last,
+    		:active_year => active_year
+    	}
+    end
+    self.where("$or" => plan_criteria_set)
   end
 
   def metal_level=(new_metal_level)

--- a/spec/controllers/employers/plan_years_controller_spec.rb
+++ b/spec/controllers/employers/plan_years_controller_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe Employers::PlanYearsController, :dbclean => :after_each do
 
   describe "GET calc_employer_contributions" do
     let(:employer_profile) { double(:plan_years => plan_year_proxy, find_plan_year: plan_year_proxy, id: "test", service_areas: [service_area_one, service_area_two], organization: organization) }
+    let(:carrier_profile) { double(:carrier_profile, id: 'carrier_id')}
     let(:reference_plan){ double("ReferencePlan", id: "id") }
     let(:plan_years){ [double("PlanYear")] }
 
@@ -85,6 +86,7 @@ RSpec.describe Employers::PlanYearsController, :dbclean => :after_each do
       it "should calculate employer contributions" do
         allow(EmployerProfile).to receive(:find).with("id").and_return(employer_profile)
         allow(Plan).to receive(:find).and_return(reference_plan)
+        allow(reference_plan).to receive(:carrier_profile_id).and_return('carrier_id')
         allow(Forms::PlanYearForm).to receive(:build).and_return(plan_years.first)
         allow(plan_years.first).to receive(:benefit_groups).and_return(benefit_groups)
         allow(benefit_groups.first).to receive(:reference_plan=).and_return(plan)
@@ -213,6 +215,7 @@ RSpec.describe Employers::PlanYearsController, :dbclean => :after_each do
     allow(benefit_group).to receive(:dental_plan_option_kind).and_return("single_carrier")
     allow(benefit_group).to receive(:elected_plans_by_option_kind).and_return([])
     allow(benefit_group).to receive(:elected_dental_plans_by_option_kind).and_return([])
+    allow(benefit_group).to receive(:build_estimated_composite_rates)
       #allow(benefit_group).to receive(:reference_plan_id).and_return(FactoryGirl.create(:plan).id)
       allow(benefit_group).to receive(:reference_plan_id).and_return(nil)
       allow(plan_year).to receive(:save).and_return(save_result)
@@ -639,7 +642,7 @@ RSpec.describe Employers::PlanYearsController, :dbclean => :after_each do
     let(:benefit_group) { FactoryGirl.create(:benefit_group) }
     let(:census_employee) { FactoryGirl.build(:census_employee) }
     let(:census_employees) { double }
-
+    let(:plan) { double }
     before do
       @employer_profile = FactoryGirl.create(:employer_profile)
       @reference_plan = benefit_group.reference_plan
@@ -650,6 +653,8 @@ RSpec.describe Employers::PlanYearsController, :dbclean => :after_each do
     it "should calculate employer contributions" do
       allow(EmployerProfile).to receive(:find).with(@employer_profile.id).and_return(@employer_profile)
       allow(Forms::PlanYearForm).to receive(:build).and_return(plan_year)
+      allow(Plan).to receive(:find).with(@reference_plan.id).and_return(@reference_plan)
+      allow(@reference_plan).to receive(:carrier_profile_id).and_return('carrier_id')
       allow(plan_year).to receive(:benefit_groups).and_return(benefit_group.to_a)
       allow(@employer_profile).to receive(:census_employees).and_return(census_employees)
       allow(census_employees).to receive(:active).and_return(@census_employees)


### PR DESCRIPTION
Looking at plans by metal level when building a plan year was not taking into account Service Area correctly - this resulted in plans being shown that did not have the relevant rating area, leading to $0 plans.

### Master Redmine ticket
* (Required!)

### Child Redmine ticket(s)
* ()
* ()

### Local build result

```
bundle exec rake parallel:spec[4]
bundle exec cucumber
```

### Latest rebase/merge tag
*

---

### Data ticket(s) Followup
* (redmine links here - optional)

### Related Pull Requests
* (github links here - optional)

---

### TODOs / Notes
#### Peer Review
* (For code review)

#### Functional Testing
* (For testing locally)

#### Deployment
* (for release manager and/or build manager)
