### PR TITLE
simple fix on cucumber

### DIFF
--- a/features/step_definitions/integration_steps.rb
+++ b/features/step_definitions/integration_steps.rb
@@ -578,8 +578,6 @@ end
 
 When(/^(.*) creates an HBX account$/) do |named_person|
   screenshot("start")
-  find('.btn', text: 'Create Account').click
-  #click_button 'Create account'
   visit '/users/sign_up'
   person = people[named_person]
 


### PR DESCRIPTION
As per cucumber scenario. it does not require to click on create account since it is been redirected to /users/sign_up so we do not need to click on create account. 