### PR TITLE
16897: Manual ER Group File Generation

### DIFF
--- a/lib/v2_group_xml_generator.rb
+++ b/lib/v2_group_xml_generator.rb
@@ -17,7 +17,8 @@ class V2GroupXmlGenerator
 
   CARRIER_ABBREVIATIONS = {
       "CareFirst": "GHMSI", "Aetna": "AHI", "Kaiser": "KFMASI", "United Health Care": "UHIC", "Delta Dental": "DDPA",
-      "Dentegra": "DTGA", "Dominion": "DMND", "Guardian": "GARD", "BestLife": "BLHI", "MetLife": "META"}
+      "Dentegra": "DTGA", "Dominion": "DMND", "Guardian": "GARD", "BestLife": "BLHI", "MetLife": "META", "Health New England, Inc.": "HNE", "Boston Medical Center HealthNet Plan": "BMCHP", "Fallon Community Health Plan, Inc.": "FCHP",
+      "Minuteman Health, Inc.": "MHI"}
 
   # Inputs
   # 1 Array of FEINS


### PR DESCRIPTION
  - carrier profiles fetching with legal_name but it does not have keys
  - I added the keys
 Please enter the commit message for your changes. Lines starting

### Master Redmine ticket
* (16897)

### Child Redmine ticket(s)
* ()
* ()

### Local build result

```
bundle exec rake parallel:spec[4]
bundle exec cucumber
```

### Latest rebase/merge tag
*

---

### Data ticket(s) Followup
* (redmine links here - optional)

### Related Pull Requests
* (github links here - optional)

---

### TODOs / Notes
#### Peer Review
* (For code review)

#### Functional Testing
* (For testing locally)

#### Deployment
* (for release manager and/or build manager)
