### PR TITLE
Revert "Ref 18528, 18529 Changes in the builder for Rake task to run …

### DIFF
--- a/app/notices/pdf_templates/employer_notice.rb
+++ b/app/notices/pdf_templates/employer_notice.rb
@@ -8,7 +8,6 @@ module PdfTemplates
     attribute :primary_identifier, String
     attribute :employee_fullname, String
     attribute :mpi_indicator, String
-    attribute :aasm_state, String
     attribute :notice_date, Date
     attribute :application_date, Date
     attribute :employer_name, String

--- a/app/notices/shop_employer_notice.rb
+++ b/app/notices/shop_employer_notice.rb
@@ -12,7 +12,6 @@ class ShopEmployerNotice < Notice
     args[:to] = employer_profile.staff_roles.first.work_email_or_best
     args[:name] = employer_profile.staff_roles.first.full_name.titleize
     args[:recipient_document_store]= employer_profile
-    self.aasm_state = args[:options][:state] if args.present? && args[:options].present?
     self.key = args[:key]
     self.header = "notices/shared/header_with_page_numbers.html.erb"
     super(args)

--- a/lib/tasks/notices/shop_employer_notice_for_all_inputs.rake
+++ b/lib/tasks/notices/shop_employer_notice_for_all_inputs.rake
@@ -13,18 +13,18 @@ namespace :notice do
         when @employer_ids
           @employer_ids.each do | employer_id |
             employer_profile_id = EmployerProfile.find(employer_id).id.to_s
-            ShopNoticesNotifierJob.perform_later(employer_profile_id, @event_name, options = {:state => "active"}) if employer_profile_id
+            ShopNoticesNotifierJob.perform_later(employer_profile_id, @event_name) if employer_profile_id
           end
         when @hbx_ids
           @hbx_ids.each do |hbx_id|
             employer_profile_id = Organization.where(hbx_id: hbx_id).first.employer_profile.id.to_s
-            ShopNoticesNotifierJob.perform_later(employer_profile_id, @event_name, options = {:state => "active"}) if employer_profile_id
+            ShopNoticesNotifierJob.perform_later(employer_profile_id, @event_name) if employer_profile_id
             puts "Notice Triggered Successfully"
           end
         when @feins
           @feins.each do |fein_id|
             employer_profile_id = Organization.where(fein: fein_id).first.employer_profile.id.to_s
-            ShopNoticesNotifierJob.perform_later(employer_profile_id, @event_name, options = {:state => "active"}) if employer_profile_id
+            ShopNoticesNotifierJob.perform_later(employer_profile_id, @event_name) if employer_profile_id
             puts "Notice Triggered Successfully"
           end
         else


### PR DESCRIPTION
…even for Active state"

This reverts commit 438a84e12a266ed054ce6163abda3363f849afc3.

 Conflicts:
	app/notices/notice.rb conflicts on line 7-11, kept the HEAD changes
	app/notices/shop_employer_notices/initial_employer_reminder_to_publish_plan_year.rb conflicts on line 14-19, kept the HEAD chages

### Master Redmine ticket
* (Required!)

### Child Redmine ticket(s)
* ()
* ()

### Local build result

```
bundle exec rake parallel:spec[4]
bundle exec cucumber
```

### Latest rebase/merge tag
*

---

### Data ticket(s) Followup
* (redmine links here - optional)

### Related Pull Requests
* (github links here - optional)

---

### TODOs / Notes
#### Peer Review
* (For code review)

#### Functional Testing
* (For testing locally)

#### Deployment
* (for release manager and/or build manager)
