### PR TITLE
Move puts statement from rake task to the

### DIFF
--- a/app/data_migrations/update_all_plan_options.rb
+++ b/app/data_migrations/update_all_plan_options.rb
@@ -3,5 +3,6 @@ require File.join(Rails.root, "lib/mongoid_migration_task")
 class UpdateAllPlanOptions < MongoidMigrationTask
   def migrate
     Plan.update_all(is_horizontal: true, is_vertical: true, is_sole_source: false)
+    puts "successfully updated the plan attributes" unless Rails.env.test?
   end
 end

--- a/lib/tasks/update_plan_offerings_at_carrier_level.rake
+++ b/lib/tasks/update_plan_offerings_at_carrier_level.rake
@@ -5,5 +5,4 @@ require File.join(Rails.root, "app", "data_migrations", "update_all_plan_options
 namespace :migrations do
   desc "It will update Plan attributes at carrier level filter"
   UpdateAllPlanOptions.define_task :plan_offerings => :environment
-  puts "successfully updated the plan attributes" unless Rails.env.test?
 end


### PR DESCRIPTION
corresponding migration file.
With this commit, the puts statement will
no longer appear everytime a rake task is run.

### Master Redmine ticket
* (Required!)

### Child Redmine ticket(s)
* ()
* ()

### Local build result

```
bundle exec rake parallel:spec[4]
bundle exec cucumber
```

### Latest rebase/merge tag
*

---

### Data ticket(s) Followup
* (redmine links here - optional)

### Related Pull Requests
* (github links here - optional)

---

### TODOs / Notes
#### Peer Review
* (For code review)

#### Functional Testing
* (For testing locally)

#### Deployment
* (for release manager and/or build manager)
