### PR TITLE
Fix typo in test script.

### DIFF
--- a/test_utilities/run_all_specs.sh
+++ b/test_utilities/run_all_specs.sh
@@ -21,4 +21,4 @@ for test_dir in `ls -1 $root/components/ | grep -v old_sponsored_benefits`; do
 done
 
 cd $root
-bundle exec rake spec:parallel[3]
+bundle exec rake parallel:spec[3]


### PR DESCRIPTION
Correct typo that doesn't run parallel specs correctly.