### PR TITLE
Upgrade overcommit

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -1,35 +1,33 @@
-
-CommitMsg:
-  CapitalizedSubject:
-    enabled: false
-
-  EmptyMessage:
-    enabled: false
-
-  TrailingPeriod:
-    enabled: true
-
-  TextWidth:
-    enabled: false
+# Use this file to configure the Overcommit hooks you wish to use. This will
+# extend the default configuration defined in:
+# https://github.com/brigade/overcommit/blob/master/config/default.yml
+#
+# At the topmost level of this YAML file is a key representing type of hook
+# being run (e.g. pre-commit, commit-msg, etc.). Within each type you can
+# customize each hook, such as whether to only run it on certain files (via
+# `include`), whether to only display output if it fails (via `quiet`), etc.
+#
+# For a complete list of hooks, see:
+# https://github.com/brigade/overcommit/tree/master/lib/overcommit/hook
+#
+# For a complete list of options that you can use to customize hooks, see:
+# https://github.com/brigade/overcommit#configuration
+#
+# Uncomment the following lines to make the configuration take effect.
 
 PreCommit:
-  ALL:
-    on_warn: fail
-
-  AuthorEmail:
-    enabled: true
-
-  AuthorName:
-    enabled: true
-
-  MergeConflicts:
-    enabled: true
-    
-  YamlSyntax:
-    enabled: true
-    
-  BundleCheck:
-    enabled: true
-
   RuboCop:
     enabled: true
+    on_warn: fail # Treat all warnings as failures
+
+#  TrailingWhitespace:
+#    enabled: true
+#    exclude:
+#      - '**/db/structure.sql' # Ignore trailing whitespace in generated files
+#
+#PostCheckout:
+#  ALL: # Special hook name that customizes all hooks of this type
+#    quiet: true # Change all post-checkout hooks to only display output on failure
+#
+#  IndexTags:
+#    enabled: true # Generate a tags file with `ctags` each time HEAD changes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -372,7 +372,7 @@ GEM
       railties (>= 3.0.0)
     fakeredis (0.7.0)
       redis (>= 3.2, < 5.0)
-    ffi (1.9.23)
+    ffi (1.10.0)
     forgery (0.7.0)
     gherkin (3.2.0)
     globalid (0.4.1)
@@ -511,7 +511,7 @@ GEM
       sprockets (>= 2.0)
     origin (2.3.1)
     orm_adapter (0.5.0)
-    overcommit (0.44.0)
+    overcommit (0.47.0)
       childprocess (~> 0.6, >= 0.6.3)
       iniparse (~> 1.4)
     parallel (1.12.1)
@@ -898,4 +898,4 @@ DEPENDENCIES
   yard-mongoid (~> 0.1.0)
 
 BUNDLED WITH
-   1.16.0
+   1.16.6


### PR DESCRIPTION
This upgrades overcommit to the latest version which has better support signing `.overcommit.yml`.