### PR TITLE
Correct missing accessors in dummy files.

### DIFF
--- a/components/benefit_sponsors/spec/dummy/app/models/benefit_group_assignment.rb
+++ b/components/benefit_sponsors/spec/dummy/app/models/benefit_group_assignment.rb
@@ -102,6 +102,23 @@ class BenefitGroupAssignment
     update_attributes(is_active: true, activated_at: TimeKeeper.datetime_of_record) unless is_active?
   end
 
+  def covered_families
+    Family.where({
+      "households.hbx_enrollments.benefit_group_assignment_id" => BSON::ObjectId.from_string(self.id)
+    })
+  end
+
+  def hbx_enrollments
+    covered_families.inject([]) do |enrollments, family|
+      family.households.each do |household|
+        enrollments += household.hbx_enrollments.show_enrollments_sans_canceled.select do |enrollment|
+          enrollment.benefit_group_assignment_id == self.id
+        end.to_a
+      end
+      enrollments
+    end
+  end
+
   aasm do
     state :initialized, initial: true
     state :coverage_selected


### PR DESCRIPTION
Correct the specs to pass.  Looks like recent code did not introduce the missing accessors in the dummy copy of BenefitGroupAssignment.