### PR TITLE
Set rspec-rails to 3.4.2 in transport_gateway

### DIFF
--- a/components/transport_gateway/Gemfile.lock
+++ b/components/transport_gateway/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
     rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
-    rspec-rails (3.8.2)
+    rspec-rails (3.4.2)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       railties (>= 3.0)
@@ -153,7 +153,7 @@ PLATFORMS
 
 DEPENDENCIES
   rspec
-  rspec-rails
+  rspec-rails (= 3.4.2)
   shoulda-matchers
   transport_gateway!
   webmock

--- a/components/transport_gateway/transport_gateway.gemspec
+++ b/components/transport_gateway/transport_gateway.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'net-ssh', '4.2.0'
   s.add_dependency 'aws-sdk', '~> 2.2.4'
 
-  s.add_development_dependency 'rspec-rails'
+  s.add_development_dependency 'rspec-rails', '3.4.2'
   s.add_development_dependency 'shoulda-matchers'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'rspec'


### PR DESCRIPTION
Hopefully locking down the `rspec-rails` gem to 3.4.2 will fix the Jenkins build issue.