### PR TITLE
updating deprecated function for finding waived employees for owner-only eligibility issue

### DIFF
--- a/app/models/census_employee.rb
+++ b/app/models/census_employee.rb
@@ -1422,7 +1422,7 @@ class CensusEmployee < CensusMember
 
   def waived?
     bga = renewal_benefit_group_assignment || active_benefit_group_assignment
-    bga.present? ? bga&.hbx_enrollment&.aasm_state == 'coverage_waived' : false
+    bga.present? ? bga&.hbx_enrollment&.is_coverage_waived? : false
   end
 
   # TODO: Implement for 16219

--- a/spec/models/census_employee_spec.rb
+++ b/spec/models/census_employee_spec.rb
@@ -1596,7 +1596,7 @@ RSpec.describe CensusEmployee, type: :model, dbclean: :after_each do
         end
         blue_collar_benefit_group_assignment1.hbx_enrollment.aasm_state = 'coverage_selected'
         blue_collar_benefit_group_assignment1.save!(:validate => false)
-        blue_collar_benefit_group_assignment2.hbx_enrollment.aasm_state = 'coverage_waived'
+        blue_collar_benefit_group_assignment2.hbx_enrollment.aasm_state = 'invalid'
         blue_collar_benefit_group_assignment2.hbx_enrollment.save!(:validate => false)
       end
 
@@ -2306,8 +2306,8 @@ RSpec.describe CensusEmployee, type: :model, dbclean: :after_each do
         benefit_group_assignments: [benefit_group_assignment]
       )
     end
-    let(:waived_hbx_enrollment_double) { double(aasm_state: 'coverage_waived', sponsored_benefit_package_id: benefit_group.id) }
-    let(:coverage_selected_hbx_enrollment_double) { double(aasm_state: 'coverage_selected', sponsored_benefit_package_id: benefit_group.id) }
+    let(:waived_hbx_enrollment_double) { double('WaivedHbxEnrollment', is_coverage_waived?: true, sponsored_benefit_package_id: benefit_group.id) }
+    let(:coverage_selected_hbx_enrollment_double) { double('CoveredHbxEnrollment', is_coverage_waived?: false, sponsored_benefit_package_id: benefit_group.id) }
 
     let(:benefit_group_assignment) {build(:benefit_sponsors_benefit_group_assignment, benefit_group: benefit_group)}
 
@@ -2324,7 +2324,7 @@ RSpec.describe CensusEmployee, type: :model, dbclean: :after_each do
   context "when active employeees has renewal benefit group" do
     let(:census_employee) {CensusEmployee.new(**valid_params)}
     let(:benefit_group_assignment) {create(:benefit_sponsors_benefit_group_assignment, benefit_group: benefit_group, census_employee: census_employee)}
-    let(:waived_hbx_enrollment_double) { double(aasm_state: 'coverage_waived') }
+    let(:waived_hbx_enrollment_double) { double('WaivedHbxEnrollment', is_coverage_waived?: true, sponsored_benefit_package_id: benefit_group.id) }
     before do
       benefit_group_assignment.update_attribute(:updated_at, benefit_group_assignment.updated_at + 1.day)
       benefit_group_assignment.plan_year.update_attribute(:aasm_state, "renewing_enrolled")


### PR DESCRIPTION
### Master Redmine ticket
* (Required!)
https://redmine.dchbx.org/issues/100860
### Child Redmine ticket(s)
* ()
* ()

### Local build result

```
bundle exec rake parallel:spec[4]
bundle exec cucumber
```

### Latest rebase/merge tag
*

---

### Data ticket(s) Followup
* (redmine links here - optional)
* We will be making data ticket(s) for existing invalid groups as this fix will only address future groups

### Related Pull Requests
* (github links here - optional)

---

### TODOs / Notes
#### Peer Review
* (For code review)

#### Functional Testing
* (For testing locally)
This fix will not fix the existing groups with that have incorrect eligibility, but it will fix the check future groups.  To test, we will need to check a new group or go back to before the groups with issues were checked for eligibility

#### Deployment
* (for release manager and/or build manager)
