### PR TITLE
add dep term date to notice params

### DIFF
--- a/lib/tasks/recurring/employee_dependent_age_off_termination.rake
+++ b/lib/tasks/recurring/employee_dependent_age_off_termination.rake
@@ -48,7 +48,7 @@ namespace :recurring do
           dep_hbx_ids = aged_off_dependents.map(&:hbx_id)
           event_name ="employee_notice_dependent_age_off_termination_non_congressional"
           observer = Observers::NoticeObserver.new
-          observer.deliver(recipient: employee_role, event_object: employee_role.census_employee, notice_event: event_name,  notice_params: {dep_hbx_ids: dep_hbx_ids})
+          observer.deliver(recipient: employee_role, event_object: employee_role.census_employee, notice_event: event_name,  notice_params: {dep_hbx_ids: dep_hbx_ids, dependent_termination_date: new_date})
           puts "Delivered employee_dependent_age_off_termination notice to #{employee_role.census_employee.full_name}" unless Rails.env.test?
         end
       end


### PR DESCRIPTION
[100925](https://redmine.dchbx.org/issues/100925)

While trying to run an age-off notice script for a previous month it was revealed that the date passed to the rake was not being passed to the notice builder. 