### PR TITLE
update GHA ubuntu version to ubunutu-latest

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         node: [9.x]
         mongodb-version: ["3.6"]
         command_configs:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
         node: [9.x]
         mongodb-version: ["3.6"]
         command_configs:


### PR DESCRIPTION
This is a build-related PR, updates ubuntu from version 18.04 to ubuntu-latest because it will be decommissioned on April 1st 2023

### Master Redmine ticket
- no ticket, build related change

### Child Redmine ticket(s)
* none

### Local build result
none

### Latest rebase/merge tag
none

### Data ticket(s) Followup
none

### Related Pull Requests
https://github.com/actions/runner-images/issues/6002
---

### TODOs / Notes
#### Peer Review
none
#### Functional Testing
none
#### Deployment
none