### PR TITLE
Revert "add date to string conversion for age-off rake (#2348)"

### DIFF
--- a/lib/tasks/recurring/employee_dependent_age_off_termination.rake
+++ b/lib/tasks/recurring/employee_dependent_age_off_termination.rake
@@ -31,7 +31,6 @@ namespace :recurring do
 
   def trigger_dep_age_off_notice(person, new_date = nil)
     new_date ||= TimeKeeper.date_of_record
-    date_string = new_date.strftime('%m/%d/%Y')
     employee_roles = person.active_employee_roles
     employee_roles.each do |employee_role|
       next if (employee_role.benefit_group.nil?)
@@ -49,7 +48,7 @@ namespace :recurring do
           dep_hbx_ids = aged_off_dependents.map(&:hbx_id)
           event_name ="employee_notice_dependent_age_off_termination_non_congressional"
           observer = Observers::NoticeObserver.new
-          observer.deliver(recipient: employee_role, event_object: employee_role.census_employee, notice_event: event_name,  notice_params: {dep_hbx_ids: dep_hbx_ids, dependent_termination_date: date_string})
+          observer.deliver(recipient: employee_role, event_object: employee_role.census_employee, notice_event: event_name,  notice_params: {dep_hbx_ids: dep_hbx_ids})
           puts "Delivered employee_dependent_age_off_termination notice to #{employee_role.census_employee.full_name}" unless Rails.env.test?
         end
       end


### PR DESCRIPTION
This reverts commit 68a03e1e50ba1abff969147caa4c67e9df1057ea.

Enabled auto-merge by mistake, rolling back this change to be tested properly

### Master Redmine ticket
[100925](https://redmine.dchbx.org/issues/100925)

