### PR TITLE
fix employer hiring broker and notices

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -657,7 +657,7 @@ module ApplicationHelper
   end
 
   def asset_data_base64(path)
-    asset = Rails.application.assets.find_asset(path)
+    asset = ::Sprockets::Railtie.build_environment(Rails.application).find_asset(path)
     throw "Could not find asset '#{path}'" if asset.nil?
     base64 = Base64.encode64(asset.to_s).gsub(/\s+/, "")
     "data:#{asset.content_type};base64,#{Rack::Utils.escape(base64)}"

--- a/components/sponsored_benefits/app/controllers/sponsored_benefits/organizations/plan_design_organizations_controller.rb
+++ b/components/sponsored_benefits/app/controllers/sponsored_benefits/organizations/plan_design_organizations_controller.rb
@@ -14,9 +14,10 @@ module SponsoredBenefits
     def create
       # old_broker_agency_profile = ::BrokerAgencyProfile.find(params[:broker_agency_id])
       broker_agency_profile = SponsoredBenefits::Organizations::BrokerAgencyProfile.find_or_initialize_broker_profile(@broker_agency_profile).broker_agency_profile
-      broker_agency_profile.plan_design_organizations.new(organization_params.merge(owner_profile_id: @broker_agency_profile.id))
+      broker_agency_profile.save unless broker_agency_profile.persisted?
 
-      if broker_agency_profile.save
+      plan_design_organization = broker_agency_profile.plan_design_organizations.create(organization_params.merge(owner_profile_id: @broker_agency_profile.id))
+      if plan_design_organization.persisted?
         flash[:success] = "Prospect Employer (#{organization_params[:legal_name]}) Added Successfully."
         redirect_to employers_organizations_broker_agency_profile_path(@broker_agency_profile)
       else

--- a/components/sponsored_benefits/spec/controllers/sponsored_benefits/organizations/plan_design_organizations_controller_spec.rb
+++ b/components/sponsored_benefits/spec/controllers/sponsored_benefits/organizations/plan_design_organizations_controller_spec.rb
@@ -178,6 +178,28 @@ module SponsoredBenefits
           end
         end
       end
+
+      context "create prospective employer for a broker" do
+        before do
+          allow(active_user).to receive(:has_hbx_staff_role?).and_return(true)
+        end
+        it "creates a prospective employer for a broker with no previous SponsoredBenefits::Organizations" do
+          bap = FactoryBot.create(:benefit_sponsors_organizations_broker_agency_profile)
+          post :create, params: { organization: valid_attributes, broker_agency_id: bap.id, format: 'js'}
+
+          expect(SponsoredBenefits::Organizations::PlanDesignOrganization.all.last.owner_profile_id).to eq(bap.id)
+        end
+
+        it "creates a prospective employer for a broker with previous SponsoredBenefits::Organizations" do
+          bap = FactoryBot.create(:benefit_sponsors_organizations_broker_agency_profile)
+          # persist SponsoredBenefits::Organizations::BrokerAgencyProfile
+          SponsoredBenefits::Organizations::Organization.create!(hbx_id: bap.hbx_id, legal_name: bap.legal_name, office_locations: bap.office_locations, fein: bap.fein, broker_agency_profile: SponsoredBenefits::Organizations::BrokerAgencyProfile.new)
+          post :create, params: { organization: valid_attributes, broker_agency_id: bap.id, format: 'js'}
+
+          expect(SponsoredBenefits::Organizations::PlanDesignOrganization.all.last.owner_profile_id).to eq(bap.id)
+        end
+      end
+
     end
 
     describe "PATCH #update" do


### PR DESCRIPTION
### Master Pivotal ticket
https://www.pivotaltracker.com/n/projects/2640062/stories/187457856#

This will be merged to `rails_upgrade_base` branch and part of Rails 4 to Rails 5.2.8.1 upgrade.

With this PR we were able to fix - 

* Able to add a prospective employer
* Employer was able to hire a broker
* Able to send notices.

Removed the loggers that was added in my earlier commit.

### Child Redmine ticket(s)
* ()
* ()

### Local build result

```
bundle exec rake parallel:spec[4]
bundle exec cucumber
```

### Latest rebase/merge tag
*

---

### Data ticket(s) Followup
* (redmine links here - optional)

### Related Pull Requests
https://github.com/health-connector/enroll/pull/2597/commits

---

### TODOs / Notes
#### Peer Review
* (For code review)

#### Functional Testing
* Able to add a prospective employer
* Employer was able to hire a broker
* Able to send notices.

#### Deployment
* (for release manager and/or build manager)
