### PR TITLE
ignore alert messages that are not strings

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -290,7 +290,7 @@ module ApplicationHelper
     flash.each do |type, messages|
       if messages.respond_to?(:each)
         messages.each do |m|
-          rendered << render(:partial => 'layouts/flash', :locals => {:type => type, :message => m}) unless m.blank?
+          rendered << render(:partial => 'layouts/flash', :locals => {:type => type, :message => m}) unless m.blank? || !m.respond_to?(:empty?)
         end
       else
         rendered << render(:partial => 'layouts/flash', :locals => {:type => type, :message => messages}) unless messages.blank? || !messages.respond_to?(:empty?)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -293,7 +293,7 @@ module ApplicationHelper
           rendered << render(:partial => 'layouts/flash', :locals => {:type => type, :message => m}) unless m.blank?
         end
       else
-        rendered << render(:partial => 'layouts/flash', :locals => {:type => type, :message => messages}) unless messages.blank? || !messages.respond_to(:empty?)
+        rendered << render(:partial => 'layouts/flash', :locals => {:type => type, :message => messages}) unless messages.blank? || !messages.respond_to?(:empty?)
       end
     end
     rendered.join('').html_safe

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -293,7 +293,7 @@ module ApplicationHelper
           rendered << render(:partial => 'layouts/flash', :locals => {:type => type, :message => m}) unless m.blank?
         end
       else
-        rendered << render(:partial => 'layouts/flash', :locals => {:type => type, :message => messages}) unless messages.blank?
+        rendered << render(:partial => 'layouts/flash', :locals => {:type => type, :message => messages}) unless messages.blank? || !messages.instance_of?(String)
       end
     end
     rendered.join('').html_safe

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -293,7 +293,7 @@ module ApplicationHelper
           rendered << render(:partial => 'layouts/flash', :locals => {:type => type, :message => m}) unless m.blank?
         end
       else
-        rendered << render(:partial => 'layouts/flash', :locals => {:type => type, :message => messages}) unless messages.blank? || !messages.instance_of?(String)
+        rendered << render(:partial => 'layouts/flash', :locals => {:type => type, :message => messages}) unless messages.blank? || !messages.respond_to(:empty?)
       end
     end
     rendered.join('').html_safe

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -62,6 +62,37 @@ RSpec.describe ApplicationHelper, :type => :helper do
     end
   end
 
+  describe "#render_flash" do
+    it "should return flash messages" do
+      flash[:notice] = "This is a Notice"
+      flash[:error] = "This is an Error"
+      expect(helper.render_flash).to include("class=\"alert alert-notice\"")
+      expect(helper.render_flash).to include("class=\"alert alert-error\"")
+    end
+
+    it "should return empty string if invalid message" do
+      flash[:notice] = true
+      expect(helper.render_flash).to eq ""
+    end
+
+    it "should return empty string if invalid nested message" do
+      flash[:notice] = [true]
+      expect(helper.render_flash).to eq ""
+    end
+
+    it "should return empty string if invalid message" do
+      flash[:notice] = nil
+      expect(helper.render_flash).to eq ""
+    end
+
+    it "should ignore invalid messages" do
+      flash[:notice] = true
+      flash[:error] = ["This is an Error", true, "this is a second error"]
+      expect(helper.render_flash).not_to include("class=\"alert alert-notice\"")
+      expect(helper.render_flash).to include("this is a second error")
+    end
+  end
+
   describe "#deductible_display" do
     let(:hbx_enrollment) {double(hbx_enrollment_members: [double, double])}
     let(:plan) { double("Plan", deductible: "$500", family_deductible: "$500 per person | $1000 per group") }


### PR DESCRIPTION
this fixes an edge case when the message for the end user includes **true** object instead of a string message