### PR TITLE
plan indicators margin update

### DIFF
--- a/app/assets/stylesheets/custom.scss.erb
+++ b/app/assets/stylesheets/custom.scss.erb
@@ -5048,6 +5048,8 @@ input:required:valid {
 .pvp-plan-indicator {
   @extend %pvp-indicator-styles;
   font-size: 16px;
+  margin-bottom: 16px;
+  display: inline-block;
 }
 
 .enr-pvp-indicator {
@@ -5067,6 +5069,8 @@ input:required:valid {
 .standard-plan-indicator {
   @extend %standard-plan-indicator-styles;
   font-size: 16px;
+  margin-bottom: 16px;
+  display: inline-block;
 }
 
 .enr-standard-plan-indicator {

--- a/app/views/ui-components/v1/cards/_metal_level_select.html.slim
+++ b/app/views/ui-components/v1/cards/_metal_level_select.html.slim
@@ -367,7 +367,6 @@ javascript:
   }
 
   function displayReferencePlanDetails(element, options) {
-    debugger;
     if(!(element || options)) {
       return
     }


### PR DESCRIPTION
Ticket: [Add whitespace between PVP/standard tags in employee reference plan selection page](https://www.pivotaltracker.com/n/projects/2640061/stories/188368504#)

Updated indicators bottom margin
Removed `debugger` from js
