### PR TITLE
display the details page when there are no employees

### DIFF
--- a/components/benefit_sponsors/app/views/benefit_sponsors/benefit_packages/benefit_packages/estimated_employee_cost_details.html.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/benefit_packages/benefit_packages/estimated_employee_cost_details.html.erb
@@ -3,7 +3,7 @@
 <% plan_kind = reference_product._type == "BenefitMarkets::Products::HealthProducts::HealthProduct" ?
                  reference_product.health_plan_kind :  reference_product.dental_plan_kind %>
 
-<% products = @employee_costs.first[:products] %>
+<% products = @employee_costs.present? ? @employee_costs.first[:products] : [] %>
 <div class="container">
   <h2><b>Benefit Package Set Up</b></h2>
   <h3><b>Selected Reference Plan</b></h3>


### PR DESCRIPTION
### Master Redmine ticket

[RM-109840](https://redmine.priv.dchbx.org/issues/109840)

### Child Redmine ticket(s)
* ()
* ()

### Local build result

```
bundle exec rake parallel:spec[4]
bundle exec cucumber
```

### Latest rebase/merge tag
*

---

### Data ticket(s) Followup
* (redmine links here - optional)

### Related Pull Requests
* (github links here - optional)

---

### TODOs / Notes
#### Peer Review
When a user clicks on the details page link on the benefit package creation page without any employees, it should not result in an error.

<img width="1676" alt="Screenshot 2024-10-29 at 4 52 40 PM" src="https://github.com/user-attachments/assets/aeec7cff-9964-4f91-ac2e-55281e859066">


#### Functional Testing
* (For testing locally)

#### Deployment
* (for release manager and/or build manager)
