### PR TITLE
fix incorrect action name in notification subscriber

### DIFF
--- a/components/notifier/app/models/notifier/notification_subscriber.rb
+++ b/components/notifier/app/models/notifier/notification_subscriber.rb
@@ -6,7 +6,7 @@ module Notifier
       [/acapi\.info\.events\..*/]
     end
 
-    def perform(event_name, _e_start, _e_end, _msg_id, payload)
+    def call(event_name, _e_start, _e_end, _msg_id, payload)
       log("NOTICE EVENT: #{event_name} #{payload}", {:severity => 'info'})
 
       NoticeKind.where(event_name: event_name.split(".")[4]).each do |notice_kind|


### PR DESCRIPTION
### Master Redmine ticket
* (Required!)

### Child Redmine ticket(s)
* ()
* ()

### Local build result

```
bundle exec rake parallel:spec[4]
bundle exec cucumber
```

### Latest rebase/merge tag
*

---

### Data ticket(s) Followup
* (redmine links here - optional)

### Related Pull Requests
* (github links here - optional)

---

### TODOs / Notes

Fix notices not unable to generate and transmit. This should always be `call` instead of `perform`. Tested this locally and able to generate a notice.

#### Peer Review
* (For code review)

#### Functional Testing
* (For testing locally)

#### Deployment
* (for release manager and/or build manager)
