### PR TITLE
Potential fix for code scanning alert no. 69: DOM text reinterpreted as HTML

### DIFF
--- a/components/sponsored_benefits/app/assets/javascripts/sponsored_benefits/plan_design_proposals.js
+++ b/components/sponsored_benefits/app/assets/javascripts/sponsored_benefits/plan_design_proposals.js
@@ -434,7 +434,7 @@ function buildBenefitGroupParams() {
 function initSlider() {
   $('.benefits-fields input.hidden-param, .dental-benefits-fields input.hidden-param').each(function() {
     $(this).closest('.form-group').find('.slider').attr('data-slider-value', $(this).val());
-    $(this).closest('.form-group').find('.slide-label').html($(this).val()+"%");
+    $(this).closest('.form-group').find('.slide-label').text($(this).val()+"%");
   });
 
   $('.benefits-fields .slider').bootstrapSlider({


### PR DESCRIPTION
Potential fix for [https://github.com/health-connector/enroll/security/code-scanning/69](https://github.com/health-connector/enroll/security/code-scanning/69)

To fix the issue, the value retrieved from `$(this).val()` should be sanitized or escaped before being inserted into the DOM using `html()`. Escaping ensures that any special characters in the input are treated as plain text rather than HTML. 

The best way to fix this is to use `text()` instead of `html()` for setting the content of the `.slide-label` element. The `text()` function automatically escapes any special characters, preventing XSS vulnerabilities.

Changes should be made to line 437 in the `initSlider` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
