### PR TITLE
fix payment history date format

### DIFF
--- a/components/benefit_sponsors/app/views/benefit_sponsors/profiles/employers/employer_profiles/my_account/accounts/_payment_history.html.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/profiles/employers/employer_profiles/my_account/accounts/_payment_history.html.erb
@@ -30,7 +30,7 @@
       <% else %>
         <% @payments.each do |payment| %>
           <tr>
-            <td><%= payment.paid_on %></td>
+            <td><%= format_date(payment.paid_on) %></td>
             <td <%= payment_amount_color_style(payment.amount) %>><%= number_to_currency(payment.amount) %></td>
             <% if payment.method_kind == "SCN" %>
               <td>CHK</td>


### PR DESCRIPTION
### Master Redmine ticket
* [(Required!)](https://redmine-app.dchbx.org/issues/115296)

### Child Redmine ticket(s)
* ()
* ()

### Local build result

```
bundle exec rake parallel:spec[4]
bundle exec cucumber
```

### Latest rebase/merge tag
*

---

### Data ticket(s) Followup
* (redmine links here - optional)

### Related Pull Requests
* (github links here - optional)

---

### TODOs / Notes
#### Peer Review
* Fixing payment history date format

Below is in Prod:

<img width="121" height="138" alt="Screenshot 2025-07-17 at 7 45 01 PM" src="https://github.com/user-attachments/assets/8aa987ca-f1da-475c-a511-ee8189d58080" />

It should look like below:

<img width="207" height="228" alt="Screenshot 2025-07-17 at 7 45 26 PM" src="https://github.com/user-attachments/assets/dacce829-64ef-4187-b208-a452fb28ef52" />

We are using an existing helper method "format_date" to format it. This happened during Rails upgrade

#### Functional Testing
* (For testing locally)

#### Deployment
* (for release manager and/or build manager)
