### PR TITLE
Fix premium age loading.

### DIFF
--- a/lib/object_builders/qhp_rate_builder.rb
+++ b/lib/object_builders/qhp_rate_builder.rb
@@ -121,7 +121,10 @@ class QhpRateBuilder
       products = ::BenefitMarkets::Products::Product.where(hios_id: /#{product_hios_id}/).select{|a| a.active_year == active_year}
       products.each do |product|
         product.premium_tables << premium_tables
-        product.premium_ages = premium_tuples.map(&:age).minmax
+        premium_ages = premium_tables.flat_map(&:premium_tuples).map(&:age).compact
+        premium_age_min = premium_ages.min
+        premium_age_max = premium_ages.max
+        product.premium_ages = Range.new(premium_age_min, premium_age_max)
         product.save
       end
     end


### PR DESCRIPTION
The minimum and maximum plan loading tasks did not take into account the fact that Mongoid 8 has dropped or introduced a bug around support for assignment of Range fields from Arrays.

Long story short, this caused the :premium_ages attribute of products to not be properly assigned during plan loading.

This patch explicitly assigns the value by range.