### PR TITLE
add logging for secure inbox notice builder errors

### DIFF
--- a/components/notifier/app/models/notifier/notice_builder.rb
+++ b/components/notifier/app/models/notifier/notice_builder.rb
@@ -240,7 +240,7 @@ module Notifier
       if notice.save
         notice
       else
-        log("ERROR: Unable to create recipient document: #{self.event_name} #{resource}", {:severity => 'error'})
+        log("ERROR: Unable to create recipient document: #{event_name} #{resource}", {:severity => 'error'})
       end
     end
 
@@ -264,7 +264,7 @@ module Notifier
       if message.save!
         message
       else
-        log("ERROR: Unable to create secure inbox message: #{self.event_name} #{resource}", {:severity => 'error'})
+        log("ERROR: Unable to create secure inbox message: #{event_name} #{resource}", {:severity => 'error'})
       end
     end
 

--- a/components/notifier/app/models/notifier/notice_builder.rb
+++ b/components/notifier/app/models/notifier/notice_builder.rb
@@ -240,7 +240,7 @@ module Notifier
       if notice.save
         notice
       else
-        # LOG ERROR
+        log("ERROR: Unable to create recipient document: #{self.event_name} #{resource}", {:severity => 'error'})
       end
     end
 
@@ -261,7 +261,11 @@ module Notifier
         receiver.id, 'documents', notice.id )}?content_type=#{notice.format}&filename=#{notice.title.gsub(/[^0-9a-z]/i,'')}.pdf&disposition=inline" + " target='_blank'>" + notice.title.gsub(/[^0-9a-z]/i,'') + "</a>"
 
       message = receiver.inbox.messages.build({ subject: subject, body: body, from: site_short_name })
-      message.save!
+      if message.save!
+        message
+      else
+        log("ERROR: Unable to create secure inbox message: #{self.event_name} #{resource}", {:severity => 'error'})
+      end
     end
 
     def sanitize_html_pdf_render


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/health-connector/enroll/blob/master/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Inert code (no impact until run, e.g. data fix or migration, manually triggered bulk process, etc.)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)
- [ ] Release (Prepares code for a release, e.g., version bumps, changelog updates, tagging, deployment scripts)

# What is the ticket # detailing the issue?

Ticket: 
[RM-115241](https://redmine-app.dchbx.org/issues/115241)

# A brief description of the changes

Current behavior:

New behavior:
Errors are logged if secure inbox message fails to build

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:


# Additional Context
Include any additional context that may be relevant to the peer review process.
