### PR TITLE
fix nfp passive renewal generation process

### DIFF
--- a/script/write_enrollment_files.rb
+++ b/script/write_enrollment_files.rb
@@ -9,6 +9,12 @@ ConnectionSlug = Struct.new(:policy_id) do
     self
   end
 
+  def confirm_select; end
+
+  def wait_for_confirms
+    true
+  end
+
   def default_exchange
     self
   end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/health-connector/enroll/blob/master/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Inert code (no impact until run, e.g. data fix or migration, manually triggered bulk process, etc.)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)
- [ ] Release (Prepares code for a release, e.g., version bumps, changelog updates, tagging, deployment scripts)

# What is the ticket # detailing the issue?

Ticket: https://app.clickup.com/t/868j0awxe

# A brief description of the changes

Current behavior: As part of the recent RoR upgrade, a compatibility issue was identified in the enrollment export script. The upgrade brought in a newer version of the messaging library, which introduced additional verification steps when processing enrollment data. The export script, which bypasses the live messaging system to write files directly to disk, was not updated to satisfy these new steps, causing it to fail during execution.

New behavior: updated the script to align with the new library requirements

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:


# Additional Context
Include any additional context that may be relevant to the peer review process.
