### PR TITLE
fix clear comparisons button

### DIFF
--- a/app/assets/javascripts/plan_comparisons.js
+++ b/app/assets/javascripts/plan_comparisons.js
@@ -301,6 +301,8 @@
    * Initialize export button handlers when document is ready
    */
   $(document).ready(function() {
+    $(document).on('click', '#clear-comparison', resetComparisonPlans);
+
     // Export to PDF handler
     $(document).on('click', '#exportComparisonPDF', function() {
       var modal = $('#planComparisonModal');

--- a/features/brokers/broker_quote_plan_comparison.feature
+++ b/features/brokers/broker_quote_plan_comparison.feature
@@ -26,6 +26,9 @@ Feature: Broker creates a quote for a prospect employer and compares plans
     And the broker selects plan offerings by metal level and enters <contribution_pct> for employee and deps
     And broker selects plans for comparison
     Then broker should see plan comparison modal
+    Then broker closes the plan comparison modal
+    And broker clears selections and selects new plans for comparison
+    Then broker should see plan comparison modal
 
     Examples:
       | contribution_pct |

--- a/features/step_definitions/broker_employee_quote_steps.rb
+++ b/features/step_definitions/broker_employee_quote_steps.rb
@@ -163,12 +163,28 @@ end
 Then(/^.+ selects plans for comparison$/) do
   page.all(".bqt-plan-comparison")[0].click
   page.all(".bqt-plan-comparison")[1].click
+  page.all(".bqt-plan-comparison")[2].click
 
   find('#view-comparison-modal').click
 end
 
 Then(/^.+ should see plan comparison modal$/) do
   expect(find("#planComparisonModal").visible?).to be_truthy
+end
+
+Then(/^.+ closes the plan comparison modal$/) do
+  find_all('.close').first.click
+  expect(find("#planComparisonModal").visible?).to be_truthy
+end
+
+Then(/^.+ clears selections and selects new plans for comparison$/) do
+  find('#clear-comparison').click
+
+  page.all(".bqt-plan-comparison")[1].click
+  page.all(".bqt-plan-comparison")[2].click
+  page.all(".bqt-plan-comparison")[3].click
+
+  find('#view-comparison-modal').click
 end
 
 Then(/^the broker should see that the save benefits button is enabled$/) do
@@ -282,6 +298,8 @@ Given(/^the Plans exist$/) do
   start_on = open_enrollment_start_on + 2.months
   FactoryBot.create(:plan, :with_rating_factors, :with_premium_tables, market: 'shop', is_standard_plan: true, metal_level: 'gold', active_year: start_on.year, deductible: 5000, csr_variant_id: "01", coverage_kind: 'health')
   FactoryBot.create(:plan, :with_rating_factors, :with_premium_tables, market: 'shop', is_standard_plan: true, metal_level: 'gold', active_year: start_on.year, deductible: 3000, csr_variant_id: "01", coverage_kind: 'health')
+  FactoryBot.create(:plan, :with_rating_factors, :with_premium_tables, market: 'shop', is_standard_plan: true, metal_level: 'gold', active_year: start_on.year, deductible: 2000, csr_variant_id: "01", coverage_kind: 'health')
+  FactoryBot.create(:plan, :with_rating_factors, :with_premium_tables, market: 'shop', is_standard_plan: true, metal_level: 'gold', active_year: start_on.year, deductible: 1000, csr_variant_id: "01", coverage_kind: 'health')
   FactoryBot.create(:plan, :with_rating_factors, :with_premium_tables, market: 'shop', is_standard_plan: true, dental_level: 'high', active_year: start_on.year, deductible: 4000, coverage_kind: 'dental')
   FactoryBot.create(:plan, :with_rating_factors, :with_premium_tables, market: 'shop', is_standard_plan: true, dental_level: 'low', active_year: start_on.year, deductible: 4000, coverage_kind: 'dental')
   FactoryBot.create(:plan, :with_rating_factors, :with_premium_tables, market: 'shop', is_standard_plan: true, metal_level: 'gold', active_year: start_on.year - 1, deductible: 5000, csr_variant_id: "01", coverage_kind: 'health')


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/health-connector/enroll/blob/master/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Inert code (no impact until run, e.g. data fix or migration, manually triggered bulk process, etc.)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)
- [ ] Release (Prepares code for a release, e.g., version bumps, changelog updates, tagging, deployment scripts)

# What is the ticket # detailing the issue?

Ticket: 
[CU-868hdytvg](https://app.clickup.com/t/868hdytvg)

# A brief description of the changes

Current behavior:
After selecting 3 plans to compare and clicking the "clear comparisons" button on BQT page, attemtping to select another plan returns an error 

New behavior:
Clear comparisons allows the user to select new plans for comparison without error

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:


# Additional Context
Include any additional context that may be relevant to the peer review process.
