### PR TITLE
add missing plans params to bqt export pdf url

### DIFF
--- a/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/plan_comparisons/_comparison_table.html.erb
+++ b/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/plan_comparisons/_comparison_table.html.erb
@@ -1,6 +1,6 @@
 <%= hidden_field_tag 'current_sort', @sort_by  %>
 <%= hidden_field_tag 'plan_ids' %>
-<%= hidden_field_tag :plan_comparison_export_pdf_url, export_organizations_plan_design_proposal_plan_comparisons_path %>
+<%= hidden_field_tag :plan_comparison_export_pdf_url, export_organizations_plan_design_proposal_plan_comparisons_path(plan_design_proposal, plans: params[:plans] ) %>
 
 <% single_plan_displayed ||= false %>
 <div class="container-fluid">

--- a/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/plan_comparisons/_comparison_table_dental.html.erb
+++ b/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/plan_comparisons/_comparison_table_dental.html.erb
@@ -1,6 +1,6 @@
 <%= hidden_field_tag 'current_sort', @sort_by  %>
 <%= hidden_field_tag 'plan_ids' %>
-<%= hidden_field_tag :plan_comparison_export_pdf_url, export_organizations_plan_design_proposal_plan_comparisons_path %>
+<%= hidden_field_tag :plan_comparison_export_pdf_url, export_organizations_plan_design_proposal_plan_comparisons_path(plan_design_proposal, plans: params[:plans] ) %>
 
 <% single_plan_displayed ||= false %>
 <div class="container-fluid">


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/health-connector/enroll/blob/master/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Inert code (no impact until run, e.g. data fix or migration, manually triggered bulk process, etc.)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)
- [ ] Release (Prepares code for a release, e.g., version bumps, changelog updates, tagging, deployment scripts)

# What is the ticket # detailing the issue?

Ticket: 
[CU-868hdytvg](https://app.clickup.com/t/868hdytvg)

# A brief description of the changes

Current behavior:
Mongo query error due to missing plan hios-id array when attempting to export pdf of bqt plan comparison

New behavior:
Plan hios-id array is present when exporting pdf


# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:


# Additional Context
Include any additional context that may be relevant to the peer review process.
