### PR TITLE
move compare plans button outside of plans sections for dental

### DIFF
--- a/components/benefit_sponsors/app/views/benefit_sponsors/sponsored_benefits/sponsored_benefits/_products.html.slim
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/sponsored_benefits/sponsored_benefits/_products.html.slim
@@ -77,12 +77,13 @@
                               span.checkmark-compare
                               span.checkmark-text style="top: -1px;"= l10n('employers.plan_years.benefit_package.compare')
 
-        - if ::EnrollRegistry.feature_enabled?(:employer_broker_ui_enhancements)
-          div style="text-align: center; margin-top: 20px; margin-bottom: 20px;"
-            button#compareSelectedPlansButton.btn.btn-primary type="button" onclick="compareSelectedPlans(event)" disabled="" style="margin-right: 10px;"
-              = l10n('employers.plan_years.benefit_package.compare_plans')
-            button#clear-comparison-button.btn.btn-default type="button" onclick="clearSelectedPlans()"
-              = l10n('employers.plan_years.benefit_package.clear_all')
+
+  - if ::EnrollRegistry.feature_enabled?(:employer_broker_ui_enhancements)
+    div style="text-align: center; margin-top: 20px; margin-bottom: 20px;"
+      button#compareSelectedPlansButton.btn.btn-primary type="button" onclick="compareSelectedPlans(event)" disabled="" style="margin-right: 10px;"
+        = l10n('employers.plan_years.benefit_package.compare_plans')
+      button#clear-comparison-button.btn.btn-default type="button" onclick="clearSelectedPlans()"
+        = l10n('employers.plan_years.benefit_package.clear_all')
 
 // Modal to view plan summary
 .modal.fade#viewSummaryModal tabindex="-1" role="dialog" aria-labelledby="myModalLabel"


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/health-connector/enroll/blob/master/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Inert code (no impact until run, e.g. data fix or migration, manually triggered bulk process, etc.)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)
- [ ] Release (Prepares code for a release, e.g., version bumps, changelog updates, tagging, deployment scripts)

# What is the ticket # detailing the issue?

Ticket: 
[CU-868j6gw9p](https://app.clickup.com/t/868j6gw9p)

# A brief description of the changes

Current behavior:
User must scroll to bottom of dental plan selections to see compare plans buttons.

New behavior:
Compare plans button is outside the plan selection area.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:


# Additional Context
Include any additional context that may be relevant to the peer review process.
