### PR TITLE
Fix pdf cost display issue

### DIFF
--- a/components/sponsored_benefits/app/assets/javascripts/sponsored_benefits/plan_design_proposals.js
+++ b/components/sponsored_benefits/app/assets/javascripts/sponsored_benefits/plan_design_proposals.js
@@ -352,7 +352,14 @@ function calcPlanDesignContributions() {
     dataType: 'script',
     data: data
   }).done(function() {
-    // do something on completion?
+    // If the comparison table is currently visible, re-render it with updated contribution
+    if ($('.plan-comparison-container').is(':visible') && selected_rpids.length > 0) {
+      if ($('#planComparisonModal').hasClass('in')) {
+        viewComparisonsModal();
+      } else {
+        viewComparisons();
+      }
+    }
   });
 
 }
@@ -780,6 +787,17 @@ function viewComparisonsModal() {
 // Export to PDF handler
 $(document).on('click', '#exportComparisonModalPDF', function() {
   var exportUrl = $('#plan_comparison_export_pdf_url').val();
+  var employerCosts = [];
+  $('.employer-cost-cell').each(function() {
+    var planId = $(this).data('plan-id');
+    var cost = $(this).text().trim().replace(/[$,]/g, '');
+    if (planId && cost) {
+      employerCosts.push(planId + ':' + cost);
+    }
+  });
+  if (employerCosts.length > 0) {
+    exportUrl += '&employer_costs=' + encodeURIComponent(employerCosts.join(','));
+  }
   window.open(exportUrl, '_blank');
 });
 

--- a/components/sponsored_benefits/app/controllers/sponsored_benefits/organizations/plan_design_proposals/plan_comparisons_controller.rb
+++ b/components/sponsored_benefits/app/controllers/sponsored_benefits/organizations/plan_design_proposals/plan_comparisons_controller.rb
@@ -20,27 +20,36 @@ module SponsoredBenefits
       end
 
       def export
+        # For dental plans, skip employer cost calculation to avoid SIC code errors
+        # Employer costs only calculated for health plans
+        employer_costs_data = if coverage_kind == 'Dental'
+                                {}
+                              elsif params[:employer_costs].present?
+                                # Use employer costs passed from the UI (same values displayed in comparison table)
+                                parse_employer_costs_from_params
+                              else
+                                calculate_employer_costs
+                              end
+
         render pdf: 'plan_comparison_export',
                template: 'sponsored_benefits/organizations/plan_design_proposals/plan_comparisons/_export',
                formats: [:html],
                disposition: 'attachment',
-               locals: { qhps: qhps, employer_costs: calculate_employer_costs, visit_types: visit_types }
+               locals: { qhps: qhps, employer_costs: employer_costs_data, visit_types: visit_types }
       end
 
       def csv
         # For dental plans, skip employer cost calculation to avoid SIC code errors
         # Employer costs only calculated for health plans
-        if coverage_kind == 'Dental'
-          employer_costs_data = {}
-        else
+        employer_costs_data = if coverage_kind == 'Dental'
+                                {}
+                              elsif params[:employer_costs].present?
           # Use employer costs from params if provided (from the comparison table)
           # Otherwise recalculate them
-          employer_costs_data = if params[:employer_costs].present?
-                                  parse_employer_costs_from_params
-                                else
-                                  calculate_employer_costs
-                                end
-        end
+                                parse_employer_costs_from_params
+                              else
+                                calculate_employer_costs
+                              end
 
         @qhps = qhps.each do |qhp|
           plan_id = qhp.plan.id
@@ -207,9 +216,7 @@ module SponsoredBenefits
 
         copy_relationship_benefits(benefit_group, temp_bg)
 
-        if benefit_group.sole_source?
-          copy_composite_tiers(benefit_group, temp_bg)
-        end
+        copy_composite_tiers(benefit_group, temp_bg) if benefit_group.sole_source?
 
         temp_bg.set_bounding_cost_plans unless plan.dental?
         temp_bg

--- a/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/plan_comparisons/_comparison_table.html.erb
+++ b/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/plan_comparisons/_comparison_table.html.erb
@@ -1,6 +1,6 @@
 <%= hidden_field_tag 'current_sort', @sort_by  %>
 <%= hidden_field_tag 'plan_ids' %>
-<%= hidden_field_tag :plan_comparison_export_pdf_url, export_organizations_plan_design_proposal_plan_comparisons_path(plan_design_proposal, plans: params[:plans] ) %>
+<%= hidden_field_tag :plan_comparison_export_pdf_url, export_organizations_plan_design_proposal_plan_comparisons_path(plan_design_proposal, plans: params[:plans], kind: 'Health' ) %>
 
 <% single_plan_displayed ||= false %>
 <div class="container-fluid">
@@ -232,15 +232,13 @@
   <br>
   <% unless single_plan_displayed %>
     <div class="col-md-offset-5 hidden-in-modal">
-      <%= link_to "Export to PDF", sponsored_benefits.export_organizations_plan_design_proposal_plan_comparisons_path(plan_design_proposal, plans: params[:plans] ) , class: "btn btn-default", id: "export-pdf-non-modal", target: "_blank" %>
+      <%= link_to "Export to PDF", sponsored_benefits.export_organizations_plan_design_proposal_plan_comparisons_path(plan_design_proposal, plans: params[:plans], kind: 'Health' ) , class: "btn btn-default", id: "export-pdf-non-modal", target: "_blank" %>
       <%= link_to "Export to CSV",  sponsored_benefits.csv_organizations_plan_design_proposal_plan_comparisons_path(plan_design_proposal, plans: params[:plans]), class: 'btn btn-default export-csv-link', id: "export-csv-non-modal", target: "_blank" %>
       <button class="btn btn-default" id="hide-detail-comparisons">Hide Details</button>
     </div>
     <script>
       $(document).ready(function() {
-        // Collect employer costs from the displayed table when CSV export is clicked
-        $('#export-csv-non-modal').on('click', function(e) {
-          e.preventDefault();
+        function collectEmployerCosts() {
           var employerCosts = [];
           $('.employer-cost-cell').each(function() {
             var planId = $(this).data('plan-id');
@@ -249,9 +247,27 @@
               employerCosts.push(planId + ':' + cost);
             }
           });
+          return employerCosts;
+        }
+
+        // Collect employer costs from the displayed table when CSV export is clicked
+        $('#export-csv-non-modal').on('click', function(e) {
+          e.preventDefault();
+          var employerCosts = collectEmployerCosts();
           var url = $(this).attr('href');
           if (employerCosts.length > 0) {
             url += '&employer_costs=' + employerCosts.join(',');
+          }
+          window.open(url, '_blank');
+        });
+
+        // Collect employer costs from the displayed table when PDF export is clicked
+        $('#export-pdf-non-modal').on('click', function(e) {
+          e.preventDefault();
+          var employerCosts = collectEmployerCosts();
+          var url = $(this).attr('href');
+          if (employerCosts.length > 0) {
+            url += '&employer_costs=' + encodeURIComponent(employerCosts.join(','));
           }
           window.open(url, '_blank');
         });

--- a/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/plan_comparisons/_comparison_table_dental.html.erb
+++ b/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/plan_comparisons/_comparison_table_dental.html.erb
@@ -1,6 +1,6 @@
 <%= hidden_field_tag 'current_sort', @sort_by  %>
 <%= hidden_field_tag 'plan_ids' %>
-<%= hidden_field_tag :plan_comparison_export_pdf_url, export_organizations_plan_design_proposal_plan_comparisons_path(plan_design_proposal, plans: params[:plans] ) %>
+<%= hidden_field_tag :plan_comparison_export_pdf_url, export_organizations_plan_design_proposal_plan_comparisons_path(plan_design_proposal, plans: params[:plans], kind: 'Dental' ) %>
 
 <% single_plan_displayed ||= false %>
 <div class="container-fluid">

--- a/components/sponsored_benefits/spec/controllers/sponsored_benefits/organizations/plan_design_proposals/plan_comparisons_controller_spec.rb
+++ b/components/sponsored_benefits/spec/controllers/sponsored_benefits/organizations/plan_design_proposals/plan_comparisons_controller_spec.rb
@@ -35,15 +35,67 @@ module SponsoredBenefits # rubocop:disable Metrics/ModuleLength
     end
 
     describe "GET #export" do
-      let(:params) { { plan_design_proposal_id: plan_design_proposal.id, plans: plan_ids } }
-
       before do
         allow_any_instance_of(Organizations::PlanDesignProposals::PlanComparisonsController).to receive(:render_to_string).and_return('')
-        get :export, params: params, format: :pdf
       end
 
-      it "returns a pdf response" do
-        expect(response.content_type).to eq('application/pdf')
+      context "without employer_costs parameter (health)" do
+        let(:params) { { plan_design_proposal_id: plan_design_proposal.id, plans: plan_ids, kind: 'Health' } }
+
+        before do
+          allow(controller).to receive(:calculate_employer_costs).and_return({})
+          get :export, params: params, format: :pdf
+        end
+
+        it "returns a pdf response" do
+          expect(response.content_type).to eq('application/pdf')
+        end
+
+        it "calls calculate_employer_costs" do
+          expect(controller).to have_received(:calculate_employer_costs)
+        end
+      end
+
+      context "with employer_costs parameter from frontend" do
+        let(:employer_costs_param) { "#{plan1.id}:150.50,#{plan2.id}:200.75" }
+        let(:params) do
+          {
+            plan_design_proposal_id: plan_design_proposal.id,
+            plans: plan_ids,
+            kind: 'Health',
+            employer_costs: employer_costs_param
+          }
+        end
+
+        before do
+          allow(controller).to receive(:calculate_employer_costs)
+          get :export, params: params, format: :pdf
+        end
+
+        it "returns a pdf response" do
+          expect(response.content_type).to eq('application/pdf')
+        end
+
+        it "does not recalculate employer costs when passed via params" do
+          expect(controller).not_to have_received(:calculate_employer_costs)
+        end
+      end
+
+      context "with dental coverage kind" do
+        let(:params) { { plan_design_proposal_id: plan_design_proposal.id, plans: plan_ids, kind: 'Dental' } }
+
+        before do
+          allow(controller).to receive(:calculate_employer_costs)
+          get :export, params: params, format: :pdf
+        end
+
+        it "returns a pdf response" do
+          expect(response.content_type).to eq('application/pdf')
+        end
+
+        it "skips employer cost calculation for dental" do
+          expect(controller).not_to have_received(:calculate_employer_costs)
+        end
       end
     end
 
@@ -256,7 +308,13 @@ module SponsoredBenefits # rubocop:disable Metrics/ModuleLength
       end
 
       context "with dental benefit group params" do
-        let(:dental_plan) { dental_plan_with_sbc_document rescue FactoryBot.create(:plan, :with_dental_coverage) }
+        let(:dental_plan) do
+
+          dental_plan_with_sbc_document
+        rescue StandardError
+          FactoryBot.create(:plan, :with_dental_coverage)
+
+        end
 
         let(:benefit_group_data) do
           {
@@ -586,6 +644,7 @@ module SponsoredBenefits # rubocop:disable Metrics/ModuleLength
         allow(controller).to receive(:cost_for_plan) do
           call_count += 1
           raise StandardError.new("Test error") if call_count == 1
+
           150.00
         end
         result = controller.send(:calculate_employer_costs)


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/health-connector/enroll/blob/master/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Inert code (no impact until run, e.g. data fix or migration, manually triggered bulk process, etc.)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)
- [ ] Release (Prepares code for a release, e.g., version bumps, changelog updates, tagging, deployment scripts)

# What is the ticket # detailing the issue?

Ticket:
https://app.clickup.com/t/868jawc76
https://app.clickup.com/t/868jaw0nt

# A brief description of the changes

Current behavior:

- The estimated monthly cost PDF values do not match the compare plan module when modifying the health plan.
- The dental compare data doesn't display in PDF

New behavior:

- The estimated monthly cost PDF values matches the compare plan module when modifying the health plan.
- The dental compare data is displaying in PDF

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:


# Additional Context
Include any additional context that may be relevant to the peer review process.
