### PR TITLE
Move python 3 from deploy stage to builder stage

### DIFF
--- a/.docker/Dockerfile.gha
+++ b/.docker/Dockerfile.gha
@@ -111,7 +111,7 @@ FROM builder AS prod_gems_and_assets
 
 RUN apt-get update -qq \
     && apt-get install -yq --no-install-recommends \
-      shared-mime-info python3 python-is-python3 \
+      shared-mime-info \
       nodejs \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /node_modules/* \

--- a/.docker/Dockerfile.gha
+++ b/.docker/Dockerfile.gha
@@ -41,13 +41,13 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
     && truncate -s 0 /var/log/*log
 
-# Add Nodejs sources and dependencies - used both during build and at runtime (e.g,. dependency for coffeescript)
+# Add Nodejs sources - needed at build time only (e.g., node-gyp during yarn install)
 RUN curl -fsSL https://deb.nodesource.com/setup_$NODE_MAJOR.x | bash -
 
-# Install Nodejs
+# Install shared-mime-info (python3/python-is-python3 removed: only needed at build time by node-gyp in prod_gems_and_assets stage)
 RUN apt-get update -qq \
   && apt-get install -yq --no-install-recommends \
-    shared-mime-info python3 python-is-python3 \
+    shared-mime-info \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /node_modules/* \
   && truncate -s 0 /var/log/*log
@@ -98,6 +98,8 @@ RUN apt-get update -qq \
     build-essential \
     git \
     libpq-dev \
+    python3 \
+    python-is-python3 \
     yarn \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/health-connector/enroll/blob/master/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Inert code (no impact until run, e.g. data fix or migration, manually triggered bulk process, etc.)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)
- [ ] Release (Prepares code for a release, e.g., version bumps, changelog updates, tagging, deployment scripts)

# What is the ticket # detailing the issue?

Ticket: https://app.clickup.com/t/868jadt6a

# A brief description of the changes

Current behavior:

New behavior: python3 and python-is-python3 have been moved from the base stage to the builder stage only.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:


# Additional Context
Include any additional context that may be relevant to the peer review process.
