### PR TITLE
add brokers helper with language list methods

### DIFF
--- a/app/helpers/brokers_helper.rb
+++ b/app/helpers/brokers_helper.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module BrokersHelper
+  # Convert an array of language codes into a human-readable sentence.
+  # - filters out blank values
+  # - maps ISO-639-1 codes to friendly names from LanguageList
+  # - falls back to the uppercase code when unknown
+  # Examples:
+  #   humanized_language_list(["en","es"]) => "English and Spanish"
+  #   humanized_language_list(nil) => ""
+  def humanized_language_list(codes)
+    codes_array = Array(codes).map(&:to_s).map(&:strip).reject(&:blank?)
+    return "" if codes_array.empty?
+
+    lookup = broker_language_lookup
+    names = codes_array.map do |code|
+      lookup[code.downcase] || code.upcase
+    end
+
+    names.to_sentence
+  end
+
+  # Accept either a broker role, a profile, or an array of ISO codes and return a
+  # humanized language list. Encapsulates nil/shape checks so views stay thin.
+  def humanized_language_list_for(subject)
+    codes = if subject.is_a?(Array)
+              subject
+            elsif subject.respond_to?(:broker_agency_profile)
+              subject.broker_agency_profile&.languages_spoken
+            elsif subject.respond_to?(:languages_spoken)
+              subject.languages_spoken
+            end
+
+    humanized_language_list(codes)
+  end
+
+  private
+
+  def broker_language_lookup
+    @broker_language_lookup ||= LanguageList::COMMON_LANGUAGES.each_with_object({}) do |li, memo|
+      key = li.iso_639_1.to_s.downcase
+      memo[key] = (li.common_name.present? ? li.common_name : li.name)
+    end
+  end
+end

--- a/app/views/shared/brokers/_broker_fields.html.erb
+++ b/app/views/shared/brokers/_broker_fields.html.erb
@@ -30,7 +30,7 @@
         <tr>
           <th><%= l10n("languages") %>:</th>
           <td>
-            <%= broker_or_staff_role.broker_agency_profile.languages_spoken.map do |lang| lang.upcase end.to_sentence %>
+            <%= humanized_language_list_for(broker_or_staff_role) %>
           </td>
         </tr>
         <tr>

--- a/spec/helpers/brokers_helper_spec.rb
+++ b/spec/helpers/brokers_helper_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BrokersHelper, type: :helper, dbclean: :after_each do
+  let(:lang_en) { double('lang_en', iso_639_1: 'en', name: 'English', common_name: nil) }
+  let(:lang_es) { double('lang_es', iso_639_1: 'es', name: 'Spanish', common_name: nil) }
+  let(:lang_el) { double('lang_el', iso_639_1: 'el', name: 'Modern Greek (1453-)', common_name: 'Greek') }
+
+  before do
+    # Stub the language list to make tests deterministic and isolated from the gem data
+    stub_const('LanguageList::COMMON_LANGUAGES', [lang_en, lang_es, lang_el])
+  end
+
+  describe '#humanized_language_list' do
+    it 'returns empty string for nil' do
+      expect(helper.humanized_language_list(nil)).to eq ''
+    end
+
+    it 'returns empty string for empty arrays or only-blank entries' do
+      expect(helper.humanized_language_list([])).to eq ''
+      expect(helper.humanized_language_list(['', nil, ' '])).to eq ''
+    end
+
+    it 'filters blank entries and maps known codes to friendly names' do
+      expect(helper.humanized_language_list(['', 'en'])).to eq 'English'
+    end
+
+    it 'strips whitespace and accepts symbol or string codes' do
+      expect(helper.humanized_language_list([:en, ' es '])).to eq 'English and Spanish'
+    end
+
+    it 'prefers common_name when available' do
+      expect(helper.humanized_language_list(['el'])).to eq 'Greek'
+    end
+
+    it 'falls back to uppercase code when unknown' do
+      expect(helper.humanized_language_list(['xx'])).to eq 'XX'
+    end
+  end
+
+  describe '#humanized_language_list_for' do
+    it 'accepts an object that responds to broker_agency_profile' do
+      profile = double('profile', languages_spoken: ['', 'en'])
+      role = double('role', broker_agency_profile: profile)
+
+      expect(helper.humanized_language_list_for(role)).to eq 'English'
+    end
+
+    it 'returns empty string when broker_agency_profile is nil' do
+      role = double('role', broker_agency_profile: nil)
+
+      expect(helper.humanized_language_list_for(role)).to eq ''
+    end
+
+    it 'accepts an array of codes directly' do
+      expect(helper.humanized_language_list_for(['en', 'es'])).to eq 'English and Spanish'
+    end
+  end
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/health-connector/enroll/blob/master/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Inert code (no impact until run, e.g. data fix or migration, manually triggered bulk process, etc.)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)
- [ ] Release (Prepares code for a release, e.g., version bumps, changelog updates, tagging, deployment scripts)

# What is the ticket # detailing the issue?

Ticket: 
CU: https://app.clickup.com/t/868hr6pn4
RM: https://redmine-app.dchbx.org/issues/118743

# A brief description of the changes

Current behavior: Language selection was displaying the codes instead of the language name under the broker application details

New behavior:  It correctly displays the language name under the broker application details

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:


# Additional Context
Include any additional context that may be relevant to the peer review process.
<img width="874" height="355" alt="Screenshot 2026-05-05 at 3 56 46 PM" src="https://github.com/user-attachments/assets/617c7fe4-26f5-43ac-8526-c8d2cbed1529" />
