### PR TITLE
include renewal statuses in benefit package member transition queries

### DIFF
--- a/components/benefit_sponsors/app/models/benefit_sponsors/benefit_packages/benefit_package.rb
+++ b/components/benefit_sponsors/app/models/benefit_sponsors/benefit_packages/benefit_package.rb
@@ -370,7 +370,10 @@ module BenefitSponsors
 
       def expire_member_benefits
         enrolled_families.each do |family|
-          enrollments = family.enrollments.by_benefit_package(self).enrolled_and_waived
+          enrollments = family.enrollments
+                              .by_benefit_package(self)
+                              .where(:aasm_state.in => (HbxEnrollment::ENROLLED_STATUSES + HbxEnrollment::RENEWAL_STATUSES + HbxEnrollment::WAIVED_STATUSES))
+                              .order(created_at: :desc)
 
           sponsored_benefits.unscoped.each do |sponsored_benefit|
             hbx_enrollment = enrollments.by_coverage_kind(sponsored_benefit.product_kind).first
@@ -382,7 +385,10 @@ module BenefitSponsors
       def terminate_member_benefits
         terminate_benefit_group_assignments
         enrolled_and_terminated_families.each do |family|
-          enrollments = family.enrollments.by_benefit_package(self).enrolled_waived_terminated_and_expired
+          enrollments = family.enrollments
+                              .by_benefit_package(self)
+                              .where(:aasm_state.in => (HbxEnrollment::ENROLLED_STATUSES + HbxEnrollment::RENEWAL_STATUSES + HbxEnrollment::WAIVED_STATUSES + HbxEnrollment::TERMINATED_STATUSES + ['coverage_expired']))
+                              .order(created_at: :desc)
           sponsored_benefits.each do |sponsored_benefit|
             enrollments.by_coverage_kind(sponsored_benefit.product_kind).each do |hbx_enrollment|
               if hbx_enrollment.effective_on > benefit_application.end_on
@@ -408,7 +414,10 @@ module BenefitSponsors
       def termination_pending_member_benefits
         terminate_benefit_group_assignments
         enrolled_and_terminated_families.each do |family|
-          enrollments = family.enrollments.by_benefit_package(self).enrolled_waived_terminated_and_expired
+          enrollments = family.enrollments
+                              .by_benefit_package(self)
+                              .where(:aasm_state.in => (HbxEnrollment::ENROLLED_STATUSES + HbxEnrollment::RENEWAL_STATUSES + HbxEnrollment::WAIVED_STATUSES + HbxEnrollment::TERMINATED_STATUSES + ['coverage_expired']))
+                              .order(created_at: :desc)
 
           sponsored_benefits.each do |sponsored_benefit|
             enrollments.by_coverage_kind(sponsored_benefit.product_kind).each do |hbx_enrollment|
@@ -434,7 +443,10 @@ module BenefitSponsors
         deactivate_benefit_group_assignments
 
         enrolled_and_terminated_families.each do |family|
-          enrollments = family.enrollments.by_benefit_package(self).enrolled_waived_terminated_and_expired
+          enrollments = family.enrollments
+                              .by_benefit_package(self)
+                              .where(:aasm_state.in => (HbxEnrollment::ENROLLED_STATUSES + HbxEnrollment::RENEWAL_STATUSES + HbxEnrollment::WAIVED_STATUSES + HbxEnrollment::TERMINATED_STATUSES + ['coverage_expired']))
+                              .order(created_at: :desc)
 
           sponsored_benefits.each do |sponsored_benefit|
             enrollments.by_coverage_kind(sponsored_benefit.product_kind).each do |hbx_enrollment|

--- a/components/benefit_sponsors/spec/models/benefit_sponsors/benefit_packages/benefit_package_spec.rb
+++ b/components/benefit_sponsors/spec/models/benefit_sponsors/benefit_packages/benefit_package_spec.rb
@@ -900,6 +900,34 @@ module BenefitSponsors
         end
       end
 
+      context 'when an auto_renewing enrollment is present' do
+        let!(:auto_renewing_enrollment) do
+          enrollment = FactoryBot.create(:hbx_enrollment, :with_enrollment_members, :with_product,
+                                         household: family.active_household,
+                                         aasm_state: 'auto_renewing',
+                                         effective_on: initial_application.start_on,
+                                         rating_area_id: initial_application.recorded_rating_area_id,
+                                         sponsored_benefit_id: initial_application.benefit_packages.first.health_sponsored_benefit.id,
+                                         sponsored_benefit_package_id: initial_application.benefit_packages.first.id,
+                                         benefit_sponsorship_id: initial_application.benefit_sponsorship.id,
+                                         employee_role_id: employee_role.id)
+          enrollment.benefit_sponsorship = benefit_sponsorship
+          enrollment.save!
+          enrollment
+        end
+
+        before do
+          initial_application.update_attributes!(aasm_state: :terminated)
+          initial_application.benefit_application_items.create(effective_period: initial_application.start_on..end_on, state: :terminated, sequence_id: 1)
+          benefit_package.terminate_member_benefits
+          auto_renewing_enrollment.reload
+        end
+
+        it 'transitions auto_renewing enrollment to coverage_terminated' do
+          expect(auto_renewing_enrollment.aasm_state).to eq 'coverage_terminated'
+        end
+      end
+
       context "terminate_benefit_group_assignments", :dbclean => :after_each do
 
         before :each do
@@ -1003,6 +1031,36 @@ module BenefitSponsors
         rbp.cancel_member_benefits(delete_benefit_package: true)
         expect(rbp.is_active).to eq false
         expect(census_employees.first.renewal_benefit_group_assignment).to eq nil
+      end
+
+      context 'when enrollment is in auto_renewing state' do
+        let!(:auto_renewing_enrollment) do
+          create(
+            :hbx_enrollment,
+            :shop,
+            household: family.active_household,
+            product: cbp.sponsored_benefits.first.reference_product,
+            coverage_kind: :health,
+            aasm_state: 'auto_renewing',
+            effective_on: ra.start_on,
+            employee_role_id: census_employee.employee_role.id,
+            sponsored_benefit_package_id: rbp.id,
+            benefit_sponsorship: bs,
+            benefit_group_assignment: renewal_bga
+          )
+        end
+        let(:auto_renewing_hbx_id) { auto_renewing_enrollment.hbx_id }
+
+        before do
+          ra.update_attributes!(aasm_state: 'canceled')
+          rbp.cancel_member_benefits
+        end
+
+        it 'cancels the auto_renewing enrollment when the renewal plan year is canceled' do
+          updated_enrollment = family.reload.active_household.hbx_enrollments.where(hbx_id: auto_renewing_hbx_id).first
+          expect(updated_enrollment).to be_present
+          expect(updated_enrollment.aasm_state).to eq 'coverage_canceled'
+        end
       end
     end
 
@@ -1227,6 +1285,38 @@ module BenefitSponsors
           expect(hbx_enrollment.aasm_state).to eq "coverage_expired"
         end
       end
+
+      context 'when an auto_renewing enrollment is present' do
+        let!(:auto_renewing_enrollment) do
+          enrollment = FactoryBot.create(:hbx_enrollment, :with_enrollment_members, :with_product,
+                                         household: family.active_household,
+                                         aasm_state: 'auto_renewing',
+                                         effective_on: initial_application.start_on,
+                                         rating_area_id: initial_application.recorded_rating_area_id,
+                                         sponsored_benefit_id: initial_application.benefit_packages.first.health_sponsored_benefit.id,
+                                         sponsored_benefit_package_id: initial_application.benefit_packages.first.id,
+                                         benefit_sponsorship_id: initial_application.benefit_sponsorship.id,
+                                         employee_role_id: employee_role.id)
+          enrollment.benefit_sponsorship = benefit_sponsorship
+          enrollment.save!
+          enrollment
+        end
+
+        before do
+          initial_application.update_attributes!(aasm_state: :expired)
+          initial_application.benefit_application_items.create(
+            effective_period: initial_application.start_on..end_on,
+            sequence_id: 1,
+            state: :expired
+          )
+          benefit_package.expire_member_benefits
+          auto_renewing_enrollment.reload
+        end
+
+        it 'does not transition auto_renewing enrollment because it is not expire_coverage-eligible' do
+          expect(auto_renewing_enrollment.aasm_state).to eq 'auto_renewing'
+        end
+      end
     end
 
     describe '.termination_pending_member_benefits' do
@@ -1376,6 +1466,38 @@ module BenefitSponsors
 
         it "should NOT update terminated_on date on enrollment if terminated_on < benefit_application end_on" do
           expect(hbx_enrollment.terminated_on).to eq hbx_enrollment_terminated_on
+        end
+      end
+
+      context 'when an auto_renewing enrollment is present' do
+        let!(:auto_renewing_enrollment) do
+          enrollment = FactoryBot.create(:hbx_enrollment, :with_enrollment_members, :with_product,
+                                         household: family.active_household,
+                                         aasm_state: 'auto_renewing',
+                                         effective_on: initial_application.start_on,
+                                         rating_area_id: initial_application.recorded_rating_area_id,
+                                         sponsored_benefit_id: initial_application.benefit_packages.first.health_sponsored_benefit.id,
+                                         sponsored_benefit_package_id: initial_application.benefit_packages.first.id,
+                                         benefit_sponsorship_id: initial_application.benefit_sponsorship.id,
+                                         employee_role_id: employee_role.id)
+          enrollment.benefit_sponsorship = benefit_sponsorship
+          enrollment.save!
+          enrollment
+        end
+
+        before do
+          initial_application.update_attributes!(aasm_state: :termination_pending)
+          initial_application.benefit_application_items.create(
+            effective_period: initial_application.start_on..end_on,
+            sequence_id: 1,
+            state: :termination_pending
+          )
+          benefit_package.termination_pending_member_benefits
+          auto_renewing_enrollment.reload
+        end
+
+        it 'transitions auto_renewing enrollment to coverage_termination_pending' do
+          expect(auto_renewing_enrollment.aasm_state).to eq 'coverage_termination_pending'
         end
       end
     end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/health-connector/enroll/blob/master/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Inert code (no impact until run, e.g. data fix or migration, manually triggered bulk process, etc.)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)
- [ ] Release (Prepares code for a release, e.g., version bumps, changelog updates, tagging, deployment scripts)

# What is the ticket # detailing the issue?

Ticket: 
CU: https://app.clickup.com/t/868hnnm5r
RM: https://redmine-app.dchbx.org/issues/118739

# A brief description of the changes

Current behavior:
Enrollment selection: BenefitPackage member-transition methods query family enrollments using scopes that omit HbxEnrollment::RENEWAL_STATUSES (e.g., auto_renewing, renewing_*), so renewal-state enrollments are skipped.
Consequence: Auto-renewing/renewing enrollments are not canceled/terminated/expired/effectuated when a benefit package or application transitions, leading to stuck enrollments and test failures.

New behavior:
- Enrollment selection: Member-transition methods in benefit_package.rb now include HbxEnrollment::RENEWAL_STATUSES when selecting enrollments for cancel/terminate/expire/effectuate operations.
- Consequence: Auto-renewing/renewing enrollments will be processed (canceled/terminated/expired/effectuated) as part of BenefitPackage transitions, preventing stuck enrollments.
- Scope: Change is targeted at BenefitPackage methods only; global HbxEnrollment scopes were intentionally NOT modified to avoid side effects.


# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:


# Additional Context
Include any additional context that may be relevant to the peer review process.
