### PR TITLE
move hardcoded wells fargo dev credentials to env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ yarn-debug.log*
 
 # Ignore actionlint binary
 actionlint
+
+# Ignore local developer environment overrides
+.env.development.local

--- a/.gitignore
+++ b/.gitignore
@@ -104,4 +104,4 @@ yarn-debug.log*
 actionlint
 
 # Ignore local developer environment overrides
-.env.development.local
+.env

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -80,9 +80,9 @@ Rails.application.configure do
 
   # for Employer Auto Pay
   config.wells_fargo_api_url = 'https://demo.e-billexpress.com:443/PayIQ/Api/SSO'
-  config.wells_fargo_api_key = 'e2dab122-114a-43a3-aaf5-78caafbbec02'
+  config.wells_fargo_api_key = ENV.fetch('WF_API_KEY', nil)
   config.wells_fargo_biller_key = '3741'
-  config.wells_fargo_api_secret = 'dchbx 2017'
+  config.wells_fargo_api_secret = ENV.fetch('WF_API_SECRET', nil)
   config.wells_fargo_api_version = '3000'
   config.wells_fargo_private_key_location = '/wfpk.pem'
   config.wells_fargo_api_date_format = '%Y-%m-%dT%H:%M:%S.0000000%z'


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/health-connector/enroll/blob/master/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Inert code (no impact until run, e.g. data fix or migration, manually triggered bulk process, etc.)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)
- [ ] Release (Prepares code for a release, e.g., version bumps, changelog updates, tagging, deployment scripts)

# What is the ticket # detailing the issue?

Ticket: 
https://dchbx.atlassian.net/browse/CCAOMDEV-14
https://app.clickup.com/t/868jk8vaf

# A brief description of the changes

Current behavior:

New behavior: update .gitignore to ignore local developer environment overrides and refactor Wells Fargo API credentials to use environment variables

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:


# Additional Context
Include any additional context that may be relevant to the peer review process.
