### PR TITLE
ignore problematic erb files in codeql scan

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,14 +1,20 @@
 # Exclude ERB template files from CodeQL analysis.
 #
-# *.js.erb and app/views/**/*.erb files contain embedded Ruby (ERB) tags like
-# <%= ... %> mixed into JavaScript or HTML. CodeQL's JS/TS and Ruby parsers both
-# trip on these with "Unexpected token" parse errors because the ERB syntax is
-# not valid in either language on its own.
+# These two patterns cover different file types, but both fail for the same
+# underlying reason: ERB tags (<%= ... %>) are not valid syntax in any of the
+# languages CodeQL's parsers expect, causing "Unexpected token" parse errors.
 #
-# It is safe to exclude these files: they are Rails server-side view templates
-# that are rendered and interpolated before reaching the browser. Any JavaScript
-# inside them is never executed as-is, so static analysis of the raw source
-# would not produce meaningful security findings anyway.
+# *.js.erb — JavaScript templates with embedded Ruby. The JS/TS parser chokes
+# on ERB tags, and the Ruby parser chokes on the surrounding JavaScript.
+#
+# views/**/*.erb — HTML, JSON, XML, and other view templates with embedded Ruby.
+# CodeQL's HTML/JS parser fails on ERB tags inside inline scripts or attributes,
+# and the Ruby parser fails on the surrounding markup.
+#
+# Both are safe to exclude: all ERB files are server-side Rails templates that
+# are rendered and interpolated before reaching the browser or an API consumer.
+# Static analysis of the raw, unrendered source would not produce meaningful
+# security findings.
 paths-ignore:
   - '**/*.js.erb'
   - '**/views/**/*.erb'

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,14 @@
+# Exclude ERB template files from CodeQL analysis.
+#
+# *.js.erb and app/views/**/*.erb files contain embedded Ruby (ERB) tags like
+# <%= ... %> mixed into JavaScript or HTML. CodeQL's JS/TS and Ruby parsers both
+# trip on these with "Unexpected token" parse errors because the ERB syntax is
+# not valid in either language on its own.
+#
+# It is safe to exclude these files: they are Rails server-side view templates
+# that are rendered and interpolated before reaching the browser. Any JavaScript
+# inside them is never executed as-is, so static analysis of the raw source
+# would not produce meaningful security findings anyway.
+paths-ignore:
+  - '**/*.js.erb'
+  - '**/views/**/*.erb'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -66,6 +66,7 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
+        config-file: ./.github/codeql/codeql-config.yml
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/health-connector/enroll/blob/master/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Inert code (no impact until run, e.g. data fix or migration, manually triggered bulk process, etc.)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)
- [ ] Release (Prepares code for a release, e.g., version bumps, changelog updates, tagging, deployment scripts)

# What is the ticket # detailing the issue?

Ticket: 
https://dchbx.atlassian.net/browse/CCAOMDEV-14
https://app.clickup.com/t/868jaazjf
https://redmine-app.dchbx.org/issues/118962

# A brief description of the changes

Current behavior: codeql flags a warning about failing to parse some files

New behavior: the .erb files which fail to get scanned are ignored.  Rationale is documented in code comments.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:


# Additional Context
Include any additional context that may be relevant to the peer review process.
