### PR TITLE
fix safari broker registration bug

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -8,6 +8,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def new
     build_resource({})
     resource.invitation_id = params[:invitation_id] if params[:invitation_id].present?
+    yield resource if block_given?
     respond_with resource
   end
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -5,9 +5,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_account_update_params, only: [:update]
 
   # GET /resource/sign_up
-  # def new
-  #   super
-  # end
+  def new
+    build_resource({})
+    resource.invitation_id = params[:invitation_id] if params[:invitation_id].present?
+    respond_with resource
+  end
 
   # POST /resource
   def create
@@ -40,7 +42,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
       if resource.active_for_authentication?
         set_flash_message :notice, :signed_up, site_name: Settings.site.short_name if is_flashing_format?
         sign_up(resource_name, resource)
-        location = after_sign_in_path_for(resource)
+        location = session[:portal].presence ||
+                   (resource.invitation_id.present? ? claim_invitation_url(id: resource.invitation_id) : nil) ||
+                   after_sign_in_path_for(resource)
         flash[:warning] = current_user.get_announcements_by_roles_and_portal(location) if current_user.present?
         respond_with resource, location: location
       else
@@ -84,7 +88,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # You can put the params you want to permit in the empty array.
   def configure_sign_up_params
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:oim_id])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:oim_id, :invitation_id])
   end
 
   def handle_recaptcha

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -15,7 +15,7 @@ class WelcomeController < ApplicationController
   private
 
   def set_cookie_attributes
-    response.headers['Set-Cookie'] = "_session_id=#{session.id}; SameSite=Strict; Secure=true; HttpOnly"
+    response.headers['Set-Cookie'] = "_session_id=#{session.id}; SameSite=Lax; Secure; HttpOnly"
     response.headers['Strict-Transport-Security'] = "max-age=31536000; includeSubDomains; preload"
   end
 end

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -37,4 +37,25 @@ RSpec.describe InvitationsController do
     end
 
   end
+
+  describe "GET claim when not logged in (require_login_and_allow_new_account)" do
+    before(:each) do
+      sign_out :user
+    end
+
+    it "stores the claim URL in session[:portal]" do
+      get :claim, params: { id: invitation_id }
+      expect(session[:portal]).to eq claim_invitation_url(id: invitation_id)
+    end
+
+    it "redirects to the sign up page with invitation_id as a query param" do
+      get :claim, params: { id: invitation_id }
+      expect(response).to redirect_to(new_user_registration_url(invitation_id: invitation_id))
+    end
+
+    it "does not attempt to find the invitation" do
+      expect(Invitation).not_to receive(:find)
+      get :claim, params: { id: invitation_id }
+    end
+  end
 end

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -4,6 +4,31 @@ require 'rails_helper'
 
 RSpec.describe Users::RegistrationsController, dbclean: :after_each do
 
+  context "new" do
+    before(:each) do
+      @request.env["devise.mapping"] = Devise.mappings[:user]
+    end
+
+    context "when invitation_id is present in params" do
+      it "populates invitation_id on the resource" do
+        get :new, params: { invitation_id: "abc123" }
+        expect(assigns(:user).invitation_id).to eq "abc123"
+      end
+
+      it "renders the sign up form" do
+        get :new, params: { invitation_id: "abc123" }
+        expect(response).to be_successful
+      end
+    end
+
+    context "when invitation_id is absent" do
+      it "leaves invitation_id blank on the resource" do
+        get :new
+        expect(assigns(:user).invitation_id).to be_blank
+      end
+    end
+  end
+
   context "create" do
     let(:curam_user){ double("CuramUser") }
     let(:email){ "test@example.com" }
@@ -46,6 +71,54 @@ RSpec.describe Users::RegistrationsController, dbclean: :after_each do
       end
 
       it "should complete sign up and redirect" do
+        post :create, params: { user: { oim_id: email, password: password, password_confirmation: password } }
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "with invitation_id in params and session[:portal] set" do
+      let(:email) { "invited_portal@test.com" }
+      let(:invitation_id) { "inv_abc123" }
+
+      before do
+        @request.env["devise.mapping"] = Devise.mappings[:user]
+        allow(CuramUser).to receive(:match_unique_login).and_return([])
+        session[:portal] = "/invitations/#{invitation_id}/claim"
+      end
+
+      it "redirects to session[:portal] rather than claim_invitation_url" do
+        post :create, params: { user: { oim_id: email, password: password, password_confirmation: password, invitation_id: invitation_id } }
+        expect(response).to redirect_to("/invitations/#{invitation_id}/claim")
+      end
+    end
+
+    context "with invitation_id in params but session[:portal] missing (Safari session loss scenario)" do
+      let(:email) { "safari_broker@test.com" }
+      let(:invitation_id) { "inv_safari456" }
+
+      before do
+        @request.env["devise.mapping"] = Devise.mappings[:user]
+        allow(CuramUser).to receive(:match_unique_login).and_return([])
+        # Simulate session[:portal] being absent (dropped by Safari SameSite behaviour)
+        session.delete(:portal)
+      end
+
+      it "falls back to claim_invitation_url using invitation_id from form params" do
+        post :create, params: { user: { oim_id: email, password: password, password_confirmation: password, invitation_id: invitation_id } }
+        expect(response).to redirect_to(claim_invitation_url(id: invitation_id))
+      end
+    end
+
+    context "without invitation_id and without session[:portal]" do
+      let(:email) { "plain_signup@test.com" }
+
+      before do
+        @request.env["devise.mapping"] = Devise.mappings[:user]
+        allow(CuramUser).to receive(:match_unique_login).and_return([])
+        session.delete(:portal)
+      end
+
+      it "falls back to after_sign_in_path_for (root path)" do
         post :create, params: { user: { oim_id: email, password: password, password_confirmation: password } }
         expect(response).to redirect_to(root_path)
       end

--- a/spec/controllers/welcome_controller_spec.rb
+++ b/spec/controllers/welcome_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe WelcomeController, :type => :controller do
       end
 
       it "has Cookie attributes" do
-        expect(response.headers["Set-Cookie"]).to match(/SameSite=Strict/)
+        expect(response.headers["Set-Cookie"]).to match(/SameSite=Lax/)
         expect(response.headers["Set-Cookie"]).to match(/HttpOnly/)
         expect(response.headers["Strict-Transport-Security"]).to match(/max-age=31536000; includeSubDomains; preload/)
       end


### PR DESCRIPTION


# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/health-connector/enroll/blob/master/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Inert code (no impact until run, e.g. data fix or migration, manually triggered bulk process, etc.)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)
- [ ] Release (Prepares code for a release, e.g., version bumps, changelog updates, tagging, deployment scripts)

# What is the ticket # detailing the issue?

Ticket: https://app.clickup.com/t/868hkp8wa

# A brief description of the changes

Current behavior:
- Brokers using Safari cannot complete registration via invitation link from email. The page loads blank or redirects to home.
- The session is lost due to a strict cookie setting (**SameSite=Strict**), causing the registration flow to break.
- Chrome and other browsers work, but Safari strictly blocks the session cookie on cross-site navigation.

New behavior:
- Brokers using Safari (and all browsers) can complete registration via invitation link from email.
- The session cookie is set with **SameSite=Lax**, allowing the flow to work as intended.
- If the session is lost, the registration flow now falls back to the invitation ID in the form, ensuring successful registration and redirect for all browsers.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:


# Additional Context
Include any additional context that may be relevant to the peer review process.
