### PR TITLE
fix second invoice generation after clode of OE

### DIFF
--- a/components/benefit_sponsors/app/models/benefit_sponsors/benefit_applications/benefit_application_enrollments_monthly_query.rb
+++ b/components/benefit_sponsors/app/models/benefit_sponsors/benefit_applications/benefit_application_enrollments_monthly_query.rb
@@ -10,13 +10,13 @@ module BenefitSponsors
 
       def call(date)
         families = Family.where({
-          :"households.hbx_enrollments.benefit_group_id".in => benefit_package_ids,
+          :"households.hbx_enrollments.sponsored_benefit_package_id".in => benefit_package_ids,
           :"households.hbx_enrollments.aasm_state".in => (HbxEnrollment::ENROLLED_STATUSES + HbxEnrollment::RENEWAL_STATUSES + HbxEnrollment::TERMINATED_STATUSES)
           }).limit(100)
 
         families.inject([]) do |enrollments, family|
           valid_enrollments = family.active_household.hbx_enrollments.where({
-            :benefit_group_id.in => benefit_package_ids,
+            :sponsored_benefit_package_id.in => benefit_package_ids,
             :effective_on.lte => date.end_of_month,
             :aasm_state.in => (HbxEnrollment::ENROLLED_STATUSES + HbxEnrollment::RENEWAL_STATUSES + HbxEnrollment::TERMINATED_STATUSES)
             }).order_by(:'submitted_at'.desc)

--- a/components/benefit_sponsors/app/models/effective/datatables/benefit_sponsors_employer_datatable.rb
+++ b/components/benefit_sponsors/app/models/effective/datatables/benefit_sponsors_employer_datatable.rb
@@ -121,8 +121,8 @@ module Effective
 
       end
 
-      def generate_invoice_link_type(row)
-        row.current_month_invoice.present? ? 'disabled' : 'post_ajax'
+      def generate_invoice_link_type(_row)
+        'post_ajax'
       end
 
       def get_latest_draft_benefit_application(benefit_sponsorship)

--- a/components/benefit_sponsors/spec/models/benefit_sponsors/concerns/employer_profile_concern_spec.rb
+++ b/components/benefit_sponsors/spec/models/benefit_sponsors/concerns/employer_profile_concern_spec.rb
@@ -6,6 +6,72 @@ require "#{BenefitSponsors::Engine.root}/spec/shared_contexts/benefit_applicatio
 
 module BenefitSponsors
   RSpec.describe Concerns::EmployerProfileConcern, type: :model, dbclean: :after_each do
+    describe "#enrollments_for_billing" do
+      include_context "setup benefit market with market catalogs and product packages"
+
+      let(:aasm_state) { :enrollment_eligible }
+
+      include_context "setup initial benefit application"
+
+      let(:person) { FactoryBot.create(:person, :with_family) }
+      let(:family) { person.primary_family }
+      let(:benefit_package) { initial_application.benefit_packages.first }
+      let(:profile) { abc_profile }
+
+      let!(:health_enrollment) do
+        FactoryBot.create(
+          :hbx_enrollment,
+          household: family.active_household,
+          coverage_kind: 'health',
+          effective_on: initial_application.start_on,
+          aasm_state: 'coverage_selected',
+          sponsored_benefit_package_id: benefit_package.id,
+          benefit_sponsorship_id: initial_application.benefit_sponsorship.id
+        )
+      end
+
+      context "when enrollment has sponsored_benefit_package_id set" do
+        it "returns the enrollment for billing" do
+          expect(profile.enrollments_for_billing).to include(health_enrollment)
+        end
+
+        it "does not return enrollments without a matching sponsored_benefit_package_id" do
+          other_enrollment = FactoryBot.create(
+            :hbx_enrollment,
+            household: family.active_household,
+            coverage_kind: 'health',
+            effective_on: initial_application.start_on,
+            aasm_state: 'coverage_selected'
+          )
+          expect(profile.enrollments_for_billing).not_to include(other_enrollment)
+        end
+      end
+
+      context "after an enrollment change to a different carrier" do
+        let!(:updated_enrollment) do
+          FactoryBot.create(
+            :hbx_enrollment,
+            household: family.active_household,
+            coverage_kind: 'health',
+            effective_on: initial_application.start_on,
+            aasm_state: 'coverage_selected',
+            sponsored_benefit_package_id: benefit_package.id,
+            benefit_sponsorship_id: initial_application.benefit_sponsorship.id
+          )
+        end
+
+        before { health_enrollment.update_attributes!(aasm_state: 'coverage_canceled') }
+
+        it "returns the updated enrollment" do
+          expect(profile.enrollments_for_billing).to include(updated_enrollment)
+        end
+
+        it "does not return the canceled original enrollment" do
+          expect(profile.enrollments_for_billing).not_to include(health_enrollment)
+        end
+      end
+    end
+
     describe "#billing_benefit_application" do
       let(:organization) do
         FactoryBot.build(:benefit_sponsors_organizations_general_organization,


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/health-connector/enroll/blob/master/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Inert code (no impact until run, e.g. data fix or migration, manually triggered bulk process, etc.)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)
- [ ] Release (Prepares code for a release, e.g., version bumps, changelog updates, tagging, deployment scripts)

# What is the ticket # detailing the issue?

Ticket: 

# A brief description of the changes

Current behavior:

New behavior:

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:


# Additional Context
Include any additional context that may be relevant to the peer review process.
