### PR TITLE
addition of false positives to brakeman ignore and update Mashall wit…

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -698,11 +698,7 @@
       },
       "user_input": null,
       "confidence": "Weak",
-      "note": "False positive: 'raw' is used deliberately because effective_datatables generates its own HTML structure that Rails would otherwise double-escape; the gem does not 
-        interpolate param values into attributes or cell content without its own escaping. The two params Brakeman traces are both sanitised before the view is reached: 
-        params[:employer_profile_id] is passed through BSON::ObjectId.from_string in the find_employer before_action (employer_profiles_controller.rb), which raises on any non-hex value and 
-        renders a 404 before the action runs; params[:billing_date] is converted to a Date object by DateParser.smart_parse in the coverage_reports action, so the raw string is never present at
-        render time."
+      "note": "False positive: 'raw' is used deliberately because effective_datatables generates its own HTML structure that Rails would otherwise double-escape; the gem does not interpolate param values into attributes or cell content without its own escaping. The two params Brakeman traces are both sanitised before the view is reached: params[:employer_profile_id] is passed through BSON::ObjectId.from_string in the find_employer before_action (employer_profiles_controller.rb), which raises on any non-hex value and renders a 404 before the action runs; params[:billing_date] is converted to a Date object by DateParser.smart_parse in the coverage_reports action, so the raw string is never present at render time."
     },
     {
       "warning_type": "Cross-Site Scripting",
@@ -721,10 +717,7 @@
       },
       "user_input": null,
       "confidence": "Weak",
-      "note": "False positive: @wf_url is assigned only when WellsFargo::BillPay::SingleSignOn#token returns HTTP 200, and its value is extracted directly from the Wells Fargo API response 
-        body (response_body[\"Url\"]). It is not constructed from employer attributes — hbx_id, dba, legal_name, and email are only POST parameters sent to the Wells Fargo API and are not 
-        reflected in the URL it returns. On any API error the SSO object is not assigned and @wf_url is never set, so the link degrades to href=\"\" rather than a user-controlled value. The 
-        attack surface for a javascript: injection therefore requires compromising the Wells Fargo API endpoint itself, which is outside the application threat model."
+      "note": "False positive: @wf_url is assigned only when WellsFargo::BillPay::SingleSignOn#token returns HTTP 200, and its value is extracted directly from the Wells Fargo API response body (response_body[\"Url\"]). It is not constructed from employer attributes — hbx_id, dba, legal_name, and email are only POST parameters sent to the Wells Fargo API and are not reflected in the URL it returns. On any API error the SSO object is not assigned and @wf_url is never set, so the link degrades to href=\"\" rather than a user-controlled value. The attack surface for a javascript: injection therefore requires compromising the Wells Fargo API endpoint itself, which is outside the application threat model."
     }
   ],
   "updated": "2026-06-02 14:35:00 -0400",

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -680,7 +680,45 @@
       "user_input": null,
       "confidence": "High",
       "note": ""
-     }
+     },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "77c855742aad234cc230133dc3b922b2e15e377a9026906a0be2643306c4dc74",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped parameter",
+      "file": "components/benefit_sponsors/app/views/benefit_sponsors/profiles/employers/employer_profiles/_coverage_reports.html.erb",
+      "line": 8,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "render_datatable(@datatable, ...)",
+      "render_path": null,
+      "location": {
+        "type": "template",
+        "template": "benefit_sponsors/profiles/employers/employer_profiles/_coverage_reports"
+      },
+      "user_input": null,
+      "confidence": "Weak",
+      "note": "False positive: params[:employer_profile_id] is validated via BSON::ObjectId.from_string before reaching the view (non-hex value raises an exception), and params[:billing_date] is parsed by DateParser.smart_parse into a Date object so the raw string never reaches HTML output. render_datatable (effective_datatables gem) generates its own escaped HTML structure and does not interpolate param values directly into attributes or cell content."
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "c368ce851ab0d5214b6e152a4c59233efbb4efca02baa3dd9dde0ea4a598dabc",
+      "check_name": "LinkToHref",
+      "message": "Unescaped model attribute in link_to href",
+      "file": "components/benefit_sponsors/app/views/benefit_sponsors/profiles/employers/employer_profiles/my_account/accounts/_pay_online_confirmation_modal.html.erb",
+      "line": 14,
+      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
+      "code": "link_to(l10n('pay_online'), @wf_url, ...)",
+      "render_path": null,
+      "location": {
+        "type": "template",
+        "template": "benefit_sponsors/profiles/employers/employer_profiles/my_account/accounts/_pay_online_confirmation_modal"
+      },
+      "user_input": null,
+      "confidence": "Weak",
+      "note": "False positive: @wf_url is generated server-side by WellsFargo::BillPay::SingleSignOn#url which always produces an https:// URL. The employer profile attributes (hbx_id, dba, legal_name) used to compose the URL are set by the enrollment system, not via free-text user input. Rails link_to HTML-escapes the href attribute by default, making a javascript: scheme injection impossible through normal enrollment flows."
+    }
   ],
   "updated": "2021-02-23 13:18:32 -0500",
   "brakeman_version": "5.0.0"

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -698,7 +698,11 @@
       },
       "user_input": null,
       "confidence": "Weak",
-      "note": "False positive: params[:employer_profile_id] is validated via BSON::ObjectId.from_string before reaching the view (non-hex value raises an exception), and params[:billing_date] is parsed by DateParser.smart_parse into a Date object so the raw string never reaches HTML output. render_datatable (effective_datatables gem) generates its own escaped HTML structure and does not interpolate param values directly into attributes or cell content."
+      "note": "False positive: 'raw' is used deliberately because effective_datatables generates its own HTML structure that Rails would otherwise double-escape; the gem does not 
+        interpolate param values into attributes or cell content without its own escaping. The two params Brakeman traces are both sanitised before the view is reached: 
+        params[:employer_profile_id] is passed through BSON::ObjectId.from_string in the find_employer before_action (employer_profiles_controller.rb), which raises on any non-hex value and 
+        renders a 404 before the action runs; params[:billing_date] is converted to a Date object by DateParser.smart_parse in the coverage_reports action, so the raw string is never present at
+        render time."
     },
     {
       "warning_type": "Cross-Site Scripting",
@@ -717,9 +721,12 @@
       },
       "user_input": null,
       "confidence": "Weak",
-      "note": "False positive: @wf_url is generated server-side by WellsFargo::BillPay::SingleSignOn#url which always produces an https:// URL. The employer profile attributes (hbx_id, dba, legal_name) used to compose the URL are set by the enrollment system, not via free-text user input. Rails link_to HTML-escapes the href attribute by default, making a javascript: scheme injection impossible through normal enrollment flows."
+      "note": "False positive: @wf_url is assigned only when WellsFargo::BillPay::SingleSignOn#token returns HTTP 200, and its value is extracted directly from the Wells Fargo API response 
+        body (response_body[\"Url\"]). It is not constructed from employer attributes — hbx_id, dba, legal_name, and email are only POST parameters sent to the Wells Fargo API and are not 
+        reflected in the URL it returns. On any API error the SSO object is not assigned and @wf_url is never set, so the link degrades to href=\"\" rather than a user-controlled value. The 
+        attack surface for a javascript: injection therefore requires compromising the Wells Fargo API endpoint itself, which is outside the application threat model."
     }
   ],
-  "updated": "2021-02-23 13:18:32 -0500",
+  "updated": "2026-06-02 14:35:00 -0400",
   "brakeman_version": "5.0.0"
 }

--- a/lib/transcript_generator.rb
+++ b/lib/transcript_generator.rb
@@ -175,7 +175,14 @@ class TranscriptGenerator
           # rows = Transcripts::ComparisonResult.new(Marshal.load(File.open(file_path))).csv_row
 
           person_importer = Importers::Transcripts::PersonTranscript.new
-          person_importer.transcript = JSON.parse(File.read(file_path))
+          raw = JSON.parse(File.read(file_path), symbolize_names: true)
+          # Outer keys are accessed with symbols (e.g. transcript[:source_is_new]).
+          # Inner sub-hashes were originally HashWithIndifferentAccess (see Transcripts::Base#transcript_template).
+          # JSON round-trip loses that, so restore indifferent access for all inner hash keys.
+          [:source, :other, :compare, :source_errors, :other_errors].each do |key|
+            raw[key] = HashWithIndifferentAccess.new(raw[key]) if raw[key].is_a?(Hash)
+          end
+          person_importer.transcript = raw
           person_importer.market = @market
           person_importer.process
 

--- a/lib/transcript_generator.rb
+++ b/lib/transcript_generator.rb
@@ -43,9 +43,7 @@ class TranscriptGenerator
     # transcript.shop = false
     transcript.find_or_build(external_obj)
 
-    File.open("#{TRANSCRIPT_PATH}/#{@count}_#{transcript.transcript[:identifier]}_#{Time.now.to_i}.bin", 'w') do |file|
-      file.write JSON.dump(transcript.transcript)
-    end
+    File.write("#{TRANSCRIPT_PATH}/#{@count}_#{transcript.transcript[:identifier]}_#{Time.now.to_i}.bin", JSON.dump(transcript.transcript))
   end
 
   def display_enrollment_transcripts

--- a/lib/transcript_generator.rb
+++ b/lib/transcript_generator.rb
@@ -43,8 +43,8 @@ class TranscriptGenerator
     # transcript.shop = false
     transcript.find_or_build(external_obj)
 
-    File.open("#{TRANSCRIPT_PATH}/#{@count}_#{transcript.transcript[:identifier]}_#{Time.now.to_i}.bin", 'wb') do |file|
-      file.write Marshal.dump(transcript.transcript)
+    File.open("#{TRANSCRIPT_PATH}/#{@count}_#{transcript.transcript[:identifier]}_#{Time.now.to_i}.bin", 'w') do |file|
+      file.write JSON.dump(transcript.transcript)
     end
   end
 
@@ -177,7 +177,7 @@ class TranscriptGenerator
           # rows = Transcripts::ComparisonResult.new(Marshal.load(File.open(file_path))).csv_row
 
           person_importer = Importers::Transcripts::PersonTranscript.new
-          person_importer.transcript = Marshal.load(File.open(file_path))
+          person_importer.transcript = JSON.load(File.open(file_path))
           person_importer.market = @market
           person_importer.process
 

--- a/lib/transcript_generator.rb
+++ b/lib/transcript_generator.rb
@@ -177,7 +177,7 @@ class TranscriptGenerator
           # rows = Transcripts::ComparisonResult.new(Marshal.load(File.open(file_path))).csv_row
 
           person_importer = Importers::Transcripts::PersonTranscript.new
-          person_importer.transcript = JSON.load(File.open(file_path))
+          person_importer.transcript = JSON.parse(File.read(file_path))
           person_importer.market = @market
           person_importer.process
 

--- a/lib/transcript_generator.rb
+++ b/lib/transcript_generator.rb
@@ -7,6 +7,9 @@ class TranscriptGenerator
   # TRANSCRIPT_PATH = "#{Rails.root}/individual_xmls_with_timestamps/ivl_transcript_batch/"
   TRANSCRIPT_PATH = "#{Rails.root}/person_transcripts"
 
+  # Keys whose values are HashWithIndifferentAccess in Transcripts::Base#transcript_template.
+  INNER_HASH_KEYS = %i[source other compare source_errors other_errors].freeze
+
 
   def initialize(market = 'individual')
     @identifier = 'hbx_id'
@@ -176,10 +179,10 @@ class TranscriptGenerator
 
           person_importer = Importers::Transcripts::PersonTranscript.new
           raw = JSON.parse(File.read(file_path), symbolize_names: true)
-          # Outer keys are accessed with symbols (e.g. transcript[:source_is_new]).
-          # Inner sub-hashes were originally HashWithIndifferentAccess (see Transcripts::Base#transcript_template).
+          # Outer keys are accessed with symbols
+          # Inner sub-hashes were originally HashWithIndifferentAccess
           # JSON round-trip loses that, so restore indifferent access for all inner hash keys.
-          [:source, :other, :compare, :source_errors, :other_errors].each do |key|
+          INNER_HASH_KEYS.each do |key|
             raw[key] = HashWithIndifferentAccess.new(raw[key]) if raw[key].is_a?(Hash)
           end
           person_importer.transcript = raw

--- a/spec/lib/transcript_generator_spec.rb
+++ b/spec/lib/transcript_generator_spec.rb
@@ -127,6 +127,15 @@ RSpec.describe TranscriptGenerator do
       expect(loaded[:source][:name]).to eq('test')
     end
 
+    it 'wraps every key listed in INNER_HASH_KEYS with HashWithIndifferentAccess' do
+      TranscriptGenerator::INNER_HASH_KEYS.each do |key|
+        next unless loaded[key]
+
+        expect(loaded[key]).to be_a(HashWithIndifferentAccess),
+          "expected loaded[#{key.inspect}] to be HashWithIndifferentAccess"
+      end
+    end
+
     it 'produces a CSV output file' do
       expect(File.exist?('person_change_sets.csv')).to be true
     end

--- a/spec/lib/transcript_generator_spec.rb
+++ b/spec/lib/transcript_generator_spec.rb
@@ -83,10 +83,10 @@ RSpec.describe TranscriptGenerator do
   describe '#display_transcripts — JSON deserialisation round-trip' do
     let(:transcript_data) do
       {
-        'hbx_id'  => 'xyz789',
-        'ssn'     => '123456789',
-        'source'  => { '_id' => 'abc', 'name' => 'test' },
-        'other'   => { '_id' => 'def', 'name' => 'other' },
+        'hbx_id' => 'xyz789',
+        'ssn' => '123456789',
+        'source' => { '_id' => 'abc', 'name' => 'test' },
+        'other' => { '_id' => 'def', 'name' => 'other' },
         'compare' => {}
       }
     end

--- a/spec/lib/transcript_generator_spec.rb
+++ b/spec/lib/transcript_generator_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe TranscriptGenerator do
 
     it 'persists all transcript keys and values' do
       file_path = Dir.glob("#{tmp_path}/*.bin").first
-      loaded = JSON.load(File.open(file_path))
+      loaded = JSON.parse(File.read(file_path))
       expect(loaded['identifier']).to eq('abc123')
       expect(loaded['name']).to eq('Jane Doe')
       expect(loaded['changes'].first['field']).to eq('email')

--- a/spec/lib/transcript_generator_spec.rb
+++ b/spec/lib/transcript_generator_spec.rb
@@ -83,60 +83,52 @@ RSpec.describe TranscriptGenerator do
   describe '#display_transcripts — JSON deserialisation round-trip' do
     let(:transcript_data) do
       {
-        'hbx_id' => 'xyz789',
-        'last_name' => 'Smith',
-        'first_name' => 'Bob',
-        'ssn' => '123456789'
+        'hbx_id'  => 'xyz789',
+        'ssn'     => '123456789',
+        'source'  => { '_id' => 'abc', 'name' => 'test' },
+        'other'   => { '_id' => 'def', 'name' => 'other' },
+        'compare' => {}
       }
     end
 
     let(:bin_file) { File.join(tmp_path, '1_xyz789_123456789.bin') }
+    let(:loaded_transcript) { [] }
 
     let(:mock_importer) do
       instance_double(
         Importers::Transcripts::PersonTranscript,
-        transcript: nil,
-        market: nil,
-        process: nil,
-        csv_row: [[
-          'xyz789', '123456789', 'Smith', 'Bob',
-          'match', 'match:ssn', '', 'Matched'
-        ]]
+        transcript: nil, market: nil, process: nil,
+        csv_row: [['xyz789', '123456789', '', '', 'match', 'match:ssn', '', 'Matched']]
       )
     end
 
     before do
-      # Write a JSON .bin file as build_transcript now produces
       File.write(bin_file, JSON.dump(transcript_data))
-
       allow(Importers::Transcripts::PersonTranscript).to receive(:new).and_return(mock_importer)
-      allow(mock_importer).to receive(:transcript=) do |val|
-        # Verify that what was loaded is a Hash with string keys (JSON round-trip)
-        expect(val).to be_a(Hash)
-        expect(val['hbx_id']).to eq('xyz789')
-      end
+      allow(mock_importer).to receive(:transcript=) { |val| loaded_transcript << val }
       allow(mock_importer).to receive(:market=)
+      described_class.new.display_transcripts
     end
 
-    it 'reads the JSON file without raising' do
-      generator = described_class.new
-      expect { generator.display_transcripts }.not_to raise_error
+    after { FileUtils.rm_f('person_change_sets.csv') }
+
+    subject(:loaded) { loaded_transcript.first }
+
+    it 'outer keys are symbol-keyed (required by transcript[:source_is_new] etc.)' do
+      expect(loaded[:hbx_id]).to eq('xyz789')
     end
 
-    it 'loads the transcript as a Hash with the correct keys' do
-      generator = described_class.new
-      generator.display_transcripts
-      expect(mock_importer).to have_received(:transcript=).once
+    it 'inner sub-hashes support string key access (required by source["_id"] etc.)' do
+      expect(loaded[:source]['_id']).to eq('abc')
+      expect(loaded[:other]['_id']).to eq('def')
+    end
+
+    it 'inner sub-hashes support symbol key access (HashWithIndifferentAccess)' do
+      expect(loaded[:source][:name]).to eq('test')
     end
 
     it 'produces a CSV output file' do
-      generator = described_class.new
-      generator.display_transcripts
       expect(File.exist?('person_change_sets.csv')).to be true
-    end
-
-    after do
-      FileUtils.rm_f('person_change_sets.csv')
     end
   end
 

--- a/spec/lib/transcript_generator_spec.rb
+++ b/spec/lib/transcript_generator_spec.rb
@@ -131,8 +131,7 @@ RSpec.describe TranscriptGenerator do
       TranscriptGenerator::INNER_HASH_KEYS.each do |key|
         next unless loaded[key]
 
-        expect(loaded[key]).to be_a(HashWithIndifferentAccess),
-          "expected loaded[#{key.inspect}] to be HashWithIndifferentAccess"
+        expect(loaded[key]).to be_a(HashWithIndifferentAccess)
       end
     end
 

--- a/spec/lib/transcript_generator_spec.rb
+++ b/spec/lib/transcript_generator_spec.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'transcript_generator'
+
+RSpec.describe TranscriptGenerator do
+  let(:tmp_path) { Dir.mktmpdir('transcript_generator_spec') }
+
+  # Redirect TRANSCRIPT_PATH to a temp dir for all tests
+  before do
+    stub_const('TranscriptGenerator::TRANSCRIPT_PATH', tmp_path)
+  end
+
+  after do
+    FileUtils.rm_rf(tmp_path)
+  end
+
+  describe '#initialize' do
+    it 'defaults market to individual' do
+      tg = described_class.new
+      expect(tg.instance_variable_get(:@market)).to eq('individual')
+    end
+
+    it 'accepts a market argument' do
+      tg = described_class.new('shop')
+      expect(tg.instance_variable_get(:@market)).to eq('shop')
+    end
+  end
+
+  describe '#build_transcript — JSON serialisation' do
+    let(:transcript_data) do
+      {
+        identifier: 'abc123',
+        name: 'Jane Doe',
+        changes: [{ field: 'email', from: 'a@b.com', to: 'c@d.com' }]
+      }
+    end
+
+    let(:mock_transcript) do
+      instance_double(
+        Transcripts::PersonTranscript,
+        transcript: transcript_data,
+        find_or_build: nil
+      )
+    end
+
+    let(:mock_external_obj) { double('external_obj') }
+
+    before do
+      allow(Transcripts::PersonTranscript).to receive(:new).and_return(mock_transcript)
+      generator = described_class.new
+      generator.instance_variable_set(:@count, 1)
+      generator.build_transcript(mock_external_obj)
+    end
+
+    it 'writes exactly one .bin file to TRANSCRIPT_PATH' do
+      files = Dir.glob("#{tmp_path}/*.bin")
+      expect(files.size).to eq(1)
+    end
+
+    it 'writes valid JSON (not Marshal binary)' do
+      file_path = Dir.glob("#{tmp_path}/*.bin").first
+      content = File.read(file_path)
+      expect { JSON.parse(content) }.not_to raise_error
+    end
+
+    it 'persists all transcript keys and values' do
+      file_path = Dir.glob("#{tmp_path}/*.bin").first
+      loaded = JSON.load(File.open(file_path))
+      expect(loaded['identifier']).to eq('abc123')
+      expect(loaded['name']).to eq('Jane Doe')
+      expect(loaded['changes'].first['field']).to eq('email')
+    end
+
+    it 'does not write Marshal binary format' do
+      file_path = Dir.glob("#{tmp_path}/*.bin").first
+      # Marshal binary files start with \x04\x08
+      raw = File.binread(file_path)
+      expect(raw).not_to start_with("\x04\x08")
+    end
+  end
+
+  describe '#display_transcripts — JSON deserialisation round-trip' do
+    let(:transcript_data) do
+      {
+        'hbx_id' => 'xyz789',
+        'last_name' => 'Smith',
+        'first_name' => 'Bob',
+        'ssn' => '123456789'
+      }
+    end
+
+    let(:bin_file) { File.join(tmp_path, '1_xyz789_123456789.bin') }
+
+    let(:mock_importer) do
+      instance_double(
+        Importers::Transcripts::PersonTranscript,
+        transcript: nil,
+        market: nil,
+        process: nil,
+        csv_row: [[
+          'xyz789', '123456789', 'Smith', 'Bob',
+          'match', 'match:ssn', '', 'Matched'
+        ]]
+      )
+    end
+
+    before do
+      # Write a JSON .bin file as build_transcript now produces
+      File.write(bin_file, JSON.dump(transcript_data))
+
+      allow(Importers::Transcripts::PersonTranscript).to receive(:new).and_return(mock_importer)
+      allow(mock_importer).to receive(:transcript=) do |val|
+        # Verify that what was loaded is a Hash with string keys (JSON round-trip)
+        expect(val).to be_a(Hash)
+        expect(val['hbx_id']).to eq('xyz789')
+      end
+      allow(mock_importer).to receive(:market=)
+    end
+
+    it 'reads the JSON file without raising' do
+      generator = described_class.new
+      expect { generator.display_transcripts }.not_to raise_error
+    end
+
+    it 'loads the transcript as a Hash with the correct keys' do
+      generator = described_class.new
+      generator.display_transcripts
+      expect(mock_importer).to have_received(:transcript=).once
+    end
+
+    it 'produces a CSV output file' do
+      generator = described_class.new
+      generator.display_transcripts
+      expect(File.exist?('person_change_sets.csv')).to be true
+    end
+
+    after do
+      FileUtils.rm_f('person_change_sets.csv')
+    end
+  end
+
+  describe 'security — no Marshal usage' do
+    it 'does not call Marshal.load anywhere in build_transcript' do
+      expect(Marshal).not_to receive(:load)
+      generator = described_class.new
+      mock_transcript = instance_double(
+        Transcripts::PersonTranscript,
+        transcript: { identifier: 'test' },
+        find_or_build: nil
+      )
+      allow(Transcripts::PersonTranscript).to receive(:new).and_return(mock_transcript)
+      generator.instance_variable_set(:@count, 1)
+      generator.build_transcript(double('obj'))
+    end
+
+    it 'does not call Marshal.dump anywhere in build_transcript' do
+      expect(Marshal).not_to receive(:dump)
+      generator = described_class.new
+      mock_transcript = instance_double(
+        Transcripts::PersonTranscript,
+        transcript: { identifier: 'test' },
+        find_or_build: nil
+      )
+      allow(Transcripts::PersonTranscript).to receive(:new).and_return(mock_transcript)
+      generator.instance_variable_set(:@count, 1)
+      generator.build_transcript(double('obj'))
+    end
+  end
+end


### PR DESCRIPTION

# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/health-connector/enroll/blob/master/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Inert code (no impact until run, e.g. data fix or migration, manually triggered bulk process, etc.)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)
- [ ] Release (Prepares code for a release, e.g., version bumps, changelog updates, tagging, deployment scripts)

# What is the ticket # detailing the issue?
[https://dchbx.atlassian.net/browse/CCAOMDEV-14](https://dchbx.atlassian.net/browse/CCAOMDEV-14)
[https://app.clickup.com/t/868jk8atw](https://app.clickup.com/t/868jk8atw)

# A brief description of the changes

Current behavior:

New behavior:
The false positives have been analyzed and added them to brakeman ignore file .
TranscriptGenerator is still actively run against production data.
* It is invoked by operations staff via data migration scripts (e.g., change_enrollment_details.rb), not via HTTP.
* The script is not dormant; it is used for enrollment and person transcript processing.
Remediation: The code has now been updated to use JSON.dump/JSON.load instead of Marshal.dump/Marshal.load, eliminating the security risk associated with Ruby's Marshal format. This is the recommended and safer approach for serialization.
# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:


# Additional Context
Include any additional context that may be relevant to the peer review process.
