### PR TITLE
update FAQs URL to point correctly

### DIFF
--- a/spec/views/ui-components/v1/layouts/_footer.html.slim_spec.rb
+++ b/spec/views/ui-components/v1/layouts/_footer.html.slim_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe "_footer.html.slim", :type => :view, dbclean: :after_each  do
       expect(rendered).to have_selector(:xpath, "//*[@id='footer-uic']/div/div[2]/div/ul/li[2]/a/span/i")
     end
 
+    it "should link to the FAQs page on MA Health Connector" do
+      expect(rendered).to have_link('FAQs', href: Settings.site.faqs_url)
+    end
+
   end
 
 end

--- a/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/system/config/templates/features/enroll_app/enroll_app.yml
@@ -19,7 +19,7 @@ registry:
           - key: :policies_url
             item: "https://dchealthlink.com/"
           - key: :faqs_url
-            item: "https://www.dchealthlink.com/Frequently-Asked-Questions"
+            item: "https://www.mahealthconnector.org/business/help-center/faqs"
           - key: :help_url
             item: "https://www.dchealthlink.com/help"
           - key: :business_resource_center_url


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/health-connector/enroll/blob/master/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Inert code (no impact until run, e.g. data fix or migration, manually triggered bulk process, etc.)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)
- [ ] Release (Prepares code for a release, e.g., version bumps, changelog updates, tagging, deployment scripts)

# What is the ticket # detailing the issue?

Ticket: 
CU: https://app.clickup.com/t/868gv0bpu
RM: https://redmine-app.dchbx.org/issues/115008
JIRA: https://dchbx.atlassian.net/browse/CCAOM-263

# A brief description of the changes

Current behavior: FAQs URL was pointing to the DC FAQ URLS

New behavior: FAQs URL was pointing to the MA FAQ URLS

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:


# Additional Context
Include any additional context that may be relevant to the peer review process.
