### PR TITLE
guard navigation sink against DOM-read url

### DIFF
--- a/components/sponsored_benefits/app/assets/javascripts/sponsored_benefits/plan_design_proposals.js
+++ b/components/sponsored_benefits/app/assets/javascripts/sponsored_benefits/plan_design_proposals.js
@@ -640,8 +640,11 @@ function saveProposalAndPublish(event) {
 
 function AddDentalToPlanDesignProposal(event) {
   saveProposal(event);
-  var url = $("#add_dental_url").val()
-  window.location.href = url
+  var url = $("#add_dental_url").val();
+  // Only navigate to same-origin relative paths (must start with a single "/").
+  if (/^\/(?!\/)/.test(url)) {
+    window.location.href = url;
+  }
 }
 
 function saveProposalAndNavigateToReview(event) {

--- a/components/sponsored_benefits/app/assets/javascripts/sponsored_benefits/plan_design_proposals.js
+++ b/components/sponsored_benefits/app/assets/javascripts/sponsored_benefits/plan_design_proposals.js
@@ -645,10 +645,12 @@ function AddDentalToPlanDesignProposal(event) {
   rawUrl = rawUrl.trim();
   try {
     var parsedUrl = new URL(rawUrl, window.location.origin);
-    if (parsedUrl.origin === window.location.origin && parsedUrl.pathname.charAt(0) === '/') {
-      window.location.href = parsedUrl.pathname + parsedUrl.search + parsedUrl.hash;
+    var isSafeProtocol = parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:';
+    if (isSafeProtocol && parsedUrl.origin === window.location.origin && parsedUrl.pathname.charAt(0) === '/') {
+      window.location.assign(parsedUrl.href);
     }
   } catch (e) {
+    // Ignore invalid URL values from DOM.
   }
 }
 

--- a/components/sponsored_benefits/app/assets/javascripts/sponsored_benefits/plan_design_proposals.js
+++ b/components/sponsored_benefits/app/assets/javascripts/sponsored_benefits/plan_design_proposals.js
@@ -640,10 +640,15 @@ function saveProposalAndPublish(event) {
 
 function AddDentalToPlanDesignProposal(event) {
   saveProposal(event);
-  var url = $("#add_dental_url").val();
-  // Only navigate to same-origin relative paths (must start with a single "/").
-  if (/^\/(?!\/)/.test(url)) {
-    window.location.href = url;
+  var rawUrl = $("#add_dental_url").val();
+  if (typeof rawUrl !== 'string') { return; }
+  rawUrl = rawUrl.trim();
+  try {
+    var parsedUrl = new URL(rawUrl, window.location.origin);
+    if (parsedUrl.origin === window.location.origin && parsedUrl.pathname.charAt(0) === '/') {
+      window.location.href = parsedUrl.pathname + parsedUrl.search + parsedUrl.hash;
+    }
+  } catch (e) {
   }
 }
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/health-connector/enroll/blob/master/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Inert code (no impact until run, e.g. data fix or migration, manually triggered bulk process, etc.)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)
- [ ] Release (Prepares code for a release, e.g., version bumps, changelog updates, tagging, deployment scripts)

# What is the ticket # detailing the issue?

Ticket: 
[https://dchbx.atlassian.net/browse/CCAOMDEV-14](https://dchbx.atlassian.net/browse/CCAOMDEV-14)
[https://app.clickup.com/t/868jad1uz](https://app.clickup.com/t/868jad1uz)
# A brief description of the changes

Current behavior:
The current method’s code reads the URL directly and assigns it to window.location.href without any validation. Please see the alert while code scanning.
GitHub alert: https://github.com/health-connector/enroll/security/code-scanning/70

New behavior:
Before assigning the url directly to window.location.href , the URL is validated .
It navigates using the fully parsed/validated URL object, never the raw DOM value
# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:


# Additional Context
Include any additional context that may be relevant to the peer review process.
