### PR TITLE
add broker agencies datatable behind feature flag

### DIFF
--- a/app/controllers/concerns/datatables/fragment_rendering.rb
+++ b/app/controllers/concerns/datatables/fragment_rendering.rb
@@ -5,6 +5,28 @@ module Datatables
   # build their table object and call render_datatable_fragment (Stimulus
   # redraws) or datatable_locals (initial full-page render of
   # datatables/_datatable).
+  #
+  # The table contract consumed here and by the app/views/datatables/_*
+  # partials (implemented by the Datatables::*Table POROs):
+  #   #param_key        - identifier used for DOM ids and the CSV filename
+  #   #columns          - ordered column defs: name, label, sortable, type
+  #                       (-> col-<name> / col-<type> th and td classes);
+  #                       optional width (inline th width) and ordered
+  #                       (collection arrives pre-sorted ascending by this
+  #                       column - renders the sort indicator on a
+  #                       non-sortable header)
+  #   #collection(hash) - filterable collection given the filter-tab attribute
+  #                       hash: a query wrapper (e.g. Queries::UserDatatableQuery)
+  #                       or a plain Mongoid criteria - anything responding to
+  #                       order_by/skip/limit/size and, when global_search? is
+  #                       true, datatable_search
+  #   #global_search?   - whether the search box renders
+  #   #filters          - nested filter tab definition (legacy shape) or nil
+  #   #filter_scopes    - filter param keys collected into #collection's hash
+  #   #csv_headers      - header row for the streamed CSV export
+  #   #csv_row(record)  - plain-text cell values for one CSV row
+  #   #row_partial      - partial rendered for each table row with locals
+  #                       row, table, row_class
   module FragmentRendering
     extend ActiveSupport::Concern
 

--- a/app/controllers/exchanges/hbx_profiles_controller.rb
+++ b/app/controllers/exchanges/hbx_profiles_controller.rb
@@ -406,7 +406,11 @@ class Exchanges::HbxProfilesController < ApplicationController
   end
 
   def broker_agency_index
-    @datatable = Effective::Datatables::BrokerAgencyDatatable.new
+    if EnrollRegistry.feature_enabled?(:refactored_datatables)
+      @broker_agencies_datatable_locals = datatable_locals(::Datatables::BrokerAgenciesTable.new, url: broker_agencies_datatable_exchanges_hbx_profiles_path)
+    else
+      @datatable = Effective::Datatables::BrokerAgencyDatatable.new
+    end
 
     #@q = params.permit(:q)[:q]
     #@broker_agency_profiles = HbxProfile.search_random(@q)
@@ -414,6 +418,21 @@ class Exchanges::HbxProfilesController < ApplicationController
 
     respond_to do |format|
       format.js {}
+    end
+  end
+
+  def broker_agencies_datatable
+    raise ActionController::RoutingError, 'Not Found' unless EnrollRegistry.feature_enabled?(:refactored_datatables)
+
+    authorize HbxProfile, :broker_agency_index?
+    table = ::Datatables::BrokerAgenciesTable.new
+    respond_to do |format|
+      format.html { render_datatable_fragment(table, url: broker_agencies_datatable_exchanges_hbx_profiles_path) }
+      format.csv do
+        stream_datatable_csv(filename: 'broker_agencies.csv',
+                             headers: table.csv_headers,
+                             rows: datatable_csv_rows(table, datatable_scoped(table)))
+      end
     end
   end
 

--- a/app/models/datatables/broker_agencies_table.rb
+++ b/app/models/datatables/broker_agencies_table.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Datatables
+  # Table definition for the Broker Agencies admin datatable (Pagy + Stimulus
+  # stack). Mirrors Effective::Datatables::BrokerAgencyDatatable: same columns,
+  # same single-tab filter definition, and the same
+  # BenefitSponsors::Organizations::Organization collection, so both stacks
+  # return identical data while the :refactored_datatables flag is being
+  # rolled out.
+  #
+  # Implements the table contract documented in Datatables::FragmentRendering.
+  # Unlike UserAccountsTable, the collection is a plain Mongoid criteria
+  # rather than a query wrapper.
+  class BrokerAgenciesTable
+    def param_key
+      'broker_agencies'
+    end
+
+    # No column is user-sortable; the collection arrives pre-sorted by
+    # legal_name, which legal_name's ordered flag surfaces as the sort
+    # indicator (matching the legacy default order of [0, asc]).
+    def columns
+      [
+        { name: 'legal_name',  label: 'Legal Name',  sortable: false, type: :string, ordered: true },
+        { name: 'dba',         label: 'Dba',         sortable: false, type: :string },
+        { name: 'fein',        label: 'FEIN',        sortable: false, type: :string },
+        { name: 'entity_kind', label: 'Entity Kind', sortable: false, type: :string },
+        { name: 'market_kind', label: 'Market Kind', sortable: false, type: :string }
+      ]
+    end
+
+    # The legacy datatable ignores the filter attributes too - its only tab
+    # ("All") narrows nothing.
+    def collection(_attributes)
+      BenefitSponsors::Organizations::Organization.broker_agency_profiles.order_by([:legal_name])
+    end
+
+    def global_search?
+      true
+    end
+
+    def filters
+      {
+        broker_agencies: [
+          { scope: 'all', label: 'All' }
+        ],
+        top_scope: :broker_agencies
+      }
+    end
+
+    def filter_scopes
+      [:broker_agencies]
+    end
+
+    def csv_headers
+      columns.map { |col| col[:label] }
+    end
+
+    def csv_row(row)
+      [
+        row.legal_name,
+        row.dba,
+        row.fein,
+        row.entity_kind.to_s.titleize,
+        row.broker_agency_profile.market_kind.to_s.titleize
+      ]
+    end
+
+    def row_partial
+      'exchanges/hbx_profiles/datatables/broker_agencies_row'
+    end
+  end
+end

--- a/app/models/datatables/user_accounts_table.rb
+++ b/app/models/datatables/user_accounts_table.rb
@@ -7,16 +7,7 @@ module Datatables
   # collection wrapper, so both stacks return identical data while the
   # :refactored_datatables flag is being rolled out.
   #
-  # The contract consumed by Datatables::FragmentRendering and the
-  # app/views/datatables/_* partials:
-  #   #param_key        - identifier used for DOM ids and the CSV filename
-  #   #columns          - ordered column defs: name, label, sortable, type, width
-  #   #collection(hash) - filterable collection (query wrapper or Mongoid criteria)
-  #   #global_search?   - whether the search box renders
-  #   #filters          - nested filter tab definition (legacy shape) or nil
-  #   #csv_headers      - header row for the streamed CSV export
-  #   #csv_row(record)  - plain-text cell values for one CSV row
-  #   #row_partial      - partial rendered for each table row
+  # Implements the table contract documented in Datatables::FragmentRendering.
   class UserAccountsTable
     def param_key
       'user_accounts'

--- a/app/views/datatables/_table.html.erb
+++ b/app/views/datatables/_table.html.erb
@@ -35,7 +35,8 @@
                       data-action="click->datatable#sortClicked" data-column="<%= col[:name] %>"
                       <% if col[:width] %>style="width: <%= col[:width] %>;"<% end %>><span class="filter-label"><%= col[:label] %></span></th>
                 <% else %>
-                  <th class="col-<%= col[:type] %> col-<%= col[:name] %> sorting_disabled"
+                  <%# ordered: the collection arrives pre-sorted ascending by this column; the legacy default order rendered the asc indicator on its (non-clickable) header. %>
+                  <th class="col-<%= col[:type] %> col-<%= col[:name] %> sorting_disabled<%= ' sorting_asc' if col[:ordered] %>"
                       rowspan="1" colspan="1" data-column-index="<%= index %>"
                       aria-label="<%= label_text %>"
                       <% if col[:width] %>style="width: <%= col[:width] %>;"<% end %>><span class="filter-label"><%= col[:label] %></span></th>

--- a/app/views/exchanges/hbx_profiles/_broker_agency_index_datatable.html.slim
+++ b/app/views/exchanges/hbx_profiles/_broker_agency_index_datatable.html.slim
@@ -2,8 +2,9 @@ p#notice = notice
 
 h1.heading-text Broker Agencies
 
-= raw render_datatable(@datatable)
-
-javascript:
-  initializeDataTables();
-  
+- if EnrollRegistry.feature_enabled?(:refactored_datatables)
+  = render partial: 'datatables/datatable', locals: @broker_agencies_datatable_locals
+- else
+  = raw render_datatable(@datatable)
+  javascript:
+    initializeDataTables();

--- a/app/views/exchanges/hbx_profiles/datatables/_broker_agencies_row.html.erb
+++ b/app/views/exchanges/hbx_profiles/datatables/_broker_agencies_row.html.erb
@@ -1,0 +1,8 @@
+<%# One Broker Agencies table row. Cell values must stay identical to the legacy BrokerAgencyDatatable column procs while both stacks coexist. %>
+<tr class="<%= row_class %>">
+  <td class="col-string col-legal_name sorting_1"><%= link_to row.legal_name, benefit_sponsors.profiles_broker_agencies_broker_agency_profile_path(row.broker_agency_profile) %></td>
+  <td class="col-string col-dba"><%= row.dba %></td>
+  <td class="col-string col-fein"><%= row.fein %></td>
+  <td class="col-string col-entity_kind"><%= row.entity_kind.to_s.titleize %></td>
+  <td class="col-string col-market_kind"><%= row.broker_agency_profile.market_kind.to_s.titleize %></td>
+</tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,6 +84,7 @@ Rails.application.routes.draw do
         get :edit_force_publish
         post :force_publish
         get :broker_agency_index
+        get :broker_agencies_datatable
         get :issuer_index
         match "marketplace_plan_years/:market" => "hbx_profiles#marketplace_plan_years", as: :marketplace_plan_years, via: :get
         match "marketplace_plan_years/:market/:year" => "hbx_profiles#marketplace_plan_year", as: :marketplace_plan_year, via: :get

--- a/spec/controllers/exchanges/hbx_profiles_controller_spec.rb
+++ b/spec/controllers/exchanges/hbx_profiles_controller_spec.rb
@@ -241,6 +241,90 @@ RSpec.describe Exchanges::HbxProfilesController, dbclean: :after_each do
       end
     end
   end
+
+  describe "Action # broker_agencies_datatable (:refactored_datatables)", dbclean: :after_each do
+    let(:permission) { double(modify_family: true) }
+    let(:hbx_staff_role) { double("hbx_staff_role", permission: permission) }
+    let(:person) { double("person", hbx_staff_role: hbx_staff_role) }
+    let(:user) { double("user", :has_hbx_staff_role? => true, :person => person, :last_portal_visited => nil) }
+
+    before :each do
+      allow(user).to receive(:has_role?).with(:hbx_staff).and_return(true)
+      allow(EnrollRegistry).to receive(:feature_enabled?).and_call_original
+      allow(EnrollRegistry).to receive(:feature_enabled?).with(:refactored_datatables).and_return(true)
+      sign_in(user)
+    end
+
+    context "when the :refactored_datatables flag is disabled" do
+      before do
+        allow(EnrollRegistry).to receive(:feature_enabled?).with(:refactored_datatables).and_return(false)
+      end
+
+      it "404s the fragment endpoint" do
+        expect { get :broker_agencies_datatable, format: :html }.to raise_error(ActionController::RoutingError)
+      end
+
+      it "builds the legacy datatable on broker_agency_index" do
+        get :broker_agency_index, xhr: true, format: :js
+        expect(assigns(:datatable)).to be_a(Effective::Datatables::BrokerAgencyDatatable)
+        expect(assigns(:broker_agencies_datatable_locals)).to be_nil
+      end
+    end
+
+    context "when the user is not a shop market admin" do
+      let(:permission) { double(modify_family: false) }
+
+      it "denies access" do
+        get :broker_agencies_datatable, format: :html
+        expect(response).not_to have_http_status(:success)
+      end
+    end
+
+    context "when authorized with the flag enabled" do
+      let!(:zeta_brokerage) do
+        FactoryBot.create(:benefit_sponsors_organizations_general_organization, :with_site,
+                          :with_broker_agency_profile, legal_name: "Zeta Brokerage")
+      end
+      let!(:alpha_brokerage) do
+        FactoryBot.create(:benefit_sponsors_organizations_general_organization, :with_site,
+                          :with_broker_agency_profile, legal_name: "Alpha Brokerage")
+      end
+
+      it "renders the table fragment without a layout" do
+        get :broker_agencies_datatable, format: :html
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template("datatables/_table")
+      end
+
+      it "prepares the datatable locals on broker_agency_index" do
+        get :broker_agency_index, xhr: true, format: :js
+        expect(assigns(:broker_agencies_datatable_locals)).to include(:table, :pagy, :records, :url)
+        expect(assigns(:datatable)).to be_nil
+      end
+
+      # The action streams via response_body=Enumerator, so the test response
+      # body must be materialized before parsing.
+      def streamed_csv_rows
+        body = response.body
+        CSV.parse(body.is_a?(String) ? body : body.to_a.join)
+      end
+
+      it "streams a CSV of all broker agencies sorted by legal name" do
+        get :broker_agencies_datatable, params: { broker_agencies: "all", per: 10 }, format: :csv
+        expect(response.headers["Content-Type"]).to eq("text/csv; charset=utf-8")
+        expect(response.headers["Content-Disposition"]).to include('filename="broker_agencies.csv"')
+        rows = streamed_csv_rows
+        expect(rows.first).to eq(["Legal Name", "Dba", "FEIN", "Entity Kind", "Market Kind"])
+        expect(rows.map(&:first)).to eq(["Legal Name", "Alpha Brokerage", "Zeta Brokerage"])
+      end
+
+      it "applies the global search to the CSV export" do
+        get :broker_agencies_datatable, params: { search: "Zeta" }, format: :csv
+        rows = streamed_csv_rows
+        expect(rows.map(&:first)).to eq(["Legal Name", "Zeta Brokerage"])
+      end
+    end
+  end
 =begin
   describe "#create" do
     let(:user) { double("User")}

--- a/spec/models/datatables/broker_agencies_table_spec.rb
+++ b/spec/models/datatables/broker_agencies_table_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Datatables::BrokerAgenciesTable, dbclean: :after_each do
+  subject(:table) { described_class.new }
+
+  describe '#columns' do
+    it 'mirrors the legacy BrokerAgencyDatatable column order and labels' do
+      expect(table.columns.map { |col| col[:name] }).to eq(
+        %w[legal_name dba fein entity_kind market_kind]
+      )
+      expect(table.columns.map { |col| col[:label] }).to eq(
+        ['Legal Name', 'Dba', 'FEIN', 'Entity Kind', 'Market Kind']
+      )
+    end
+
+    it 'marks no column sortable' do
+      expect(table.columns.none? { |col| col[:sortable] }).to be(true)
+    end
+
+    it 'flags legal_name as the pre-ordered column carrying the sort indicator' do
+      ordered = table.columns.select { |col| col[:ordered] }.map { |col| col[:name] }
+      expect(ordered).to eq(['legal_name'])
+    end
+  end
+
+  describe '#collection' do
+    let!(:zeta_brokerage) do
+      FactoryBot.create(:benefit_sponsors_organizations_general_organization, :with_site,
+                        :with_broker_agency_profile, legal_name: 'Zeta Brokerage')
+    end
+    let!(:alpha_brokerage) do
+      FactoryBot.create(:benefit_sponsors_organizations_general_organization, :with_site,
+                        :with_broker_agency_profile, legal_name: 'Alpha Brokerage')
+    end
+    let!(:hbx_organization) do
+      FactoryBot.create(:benefit_sponsors_organizations_general_organization, :with_site,
+                        :with_hbx_profile, legal_name: 'Not A Brokerage')
+    end
+
+    it 'returns only broker agency organizations, pre-sorted by legal name' do
+      expect(table.collection({}).map(&:legal_name)).to eq(['Alpha Brokerage', 'Zeta Brokerage'])
+    end
+
+    it 'ignores the filter attributes, like the legacy single-tab datatable' do
+      expect(table.collection(broker_agencies: 'all').map(&:legal_name)).to eq(['Alpha Brokerage', 'Zeta Brokerage'])
+    end
+
+    it 'is a plain Mongoid criteria supporting the datatable_search scope' do
+      expect(table.collection({}).datatable_search('Zeta').map(&:legal_name)).to eq(['Zeta Brokerage'])
+    end
+  end
+
+  describe '#filters' do
+    it 'reproduces the legacy single-tab filter definition' do
+      expect(table.filters[:top_scope]).to eq(:broker_agencies)
+      expect(table.filters[:broker_agencies].map { |filter| filter[:scope] }).to eq(['all'])
+    end
+  end
+
+  describe 'csv export' do
+    let(:organization) do
+      FactoryBot.create(:benefit_sponsors_organizations_general_organization, :with_site,
+                        :with_broker_agency_profile, legal_name: 'Acme Brokers', dba: 'Acme')
+    end
+
+    it 'includes every column in the headers' do
+      expect(table.csv_headers).to eq(['Legal Name', 'Dba', 'FEIN', 'Entity Kind', 'Market Kind'])
+    end
+
+    it 'renders the same plain-text values the table cells show' do
+      expect(table.csv_row(organization)).to eq(
+        ['Acme Brokers', 'Acme', organization.fein, 'C Corporation', 'Shop']
+      )
+    end
+  end
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/health-connector/enroll/blob/master/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Inert code (no impact until run, e.g. data fix or migration, manually triggered bulk process, etc.)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)
- [ ] Release (Prepares code for a release, e.g., version bumps, changelog updates, tagging, deployment scripts)

# What is the ticket # detailing the issue?

Ticket: https://app.clickup.com/t/868jab71m

# A brief description of the changes

This is Phase 2 of the effective_datatables refactor (Pagy + Mongoid + Stimulus; plan: `thoughts/plans/cca/2026-06-10-effective-datatables-refactor.md` in ea_enterprise). It ports the admin Broker Agencies tab to the new datatable stack behind the existing `:refactored_datatables` feature flag (default off), and performs the extraction pass that generalizes the Phase 1 scaffold for its second consumer.

**Stacked PR:** based on Phase 1 (#3200, branch `datatables_refactor_phase1_user_accounts`), which must merge first.

Current behavior:

The admin Broker Agencies tab (Admin → Brokers → Broker Agencies) renders via the legacy effective_datatables stack (jQuery DataTables).

New behavior:

With `:refactored_datatables` enabled, the tab renders via the new datatable stack; with the flag disabled, the legacy page is unchanged. Specifically:

- New `Datatables::BrokerAgenciesTable` PORO whose collection is a plain Mongoid criteria (`BenefitSponsors::Organizations::Organization.broker_agency_profiles.order_by([:legal_name])` with `Organization.datatable_search`) — proves the table contract works without a query wrapper.
- New `broker_agencies_datatable` action + route on `Exchanges::HbxProfilesController`: HTML fragment for Stimulus redraws plus streamed full-collection CSV; authorized via Pundit `HbxProfilePolicy#broker_agency_index?`; returns 404 when the flag is off. Flag branch lives in `broker_agency_index` / `_broker_agency_index_datatable.html.slim`; row partial is `_broker_agencies_row.html.erb`.
- Extraction pass: table contract documentation moved to `Datatables::FragmentRendering` (the shared consumer); new optional column key `ordered: true` renders the legacy default-order sort indicator (`sorting_asc` on a non-sortable header) — the Broker Agencies flag-OFF DOM snapshot showed jQuery DataTables does this for default order `[0,'asc']` even with no sortable columns.
- UI is DOM-parity-identical to the legacy stack: flag-OFF and flag-ON snapshots were structurally diffed — 121 nodes identical.

Verification:
- RuboCop clean on branch files.
- `spec/models/datatables/broker_agencies_table_spec.rb` (9 examples) and `spec/controllers/exchanges/hbx_profiles_controller_spec.rb` (89 examples): 0 failures.
- `features/admin/user_account.feature` green in BOTH flag states (regression check: the generalization didn't break the Phase 1 page).
- Browser-verified: search/clear, selectric length select (clicked via widget UI), filter tab, CSV download (200), and both migrated pages working flag-ON simultaneously with zero console errors.

QA steps:
1. Enable `REFACTORED_DATATABLES_IS_ENABLED=true`, log in as an HBX admin, and open Admin → Brokers → Broker Agencies.
2. Verify the table renders with Legal Name / Dba / FEIN / Entity Kind / Market Kind columns, sorted by legal name.
3. Search by legal name, FEIN, or HBX ID — results filter; the clear button restores the full list.
4. Change the per-page select — the table redraws.
5. Click the CSV and Excel buttons — each downloads a CSV of all filtered rows.
6. Click a legal-name link — it opens the broker agency profile.
7. Disable the flag — the page renders the legacy DataTables table unchanged, and `/exchanges/hbx_profiles/broker_agencies_datatable` returns 404.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: `REFACTORED_DATATABLES_IS_ENABLED` (existing flag for `:refactored_datatables`, introduced in Phase 1; default off) — applies to CCA.


# Additional Context
This PR is stacked on Phase 1 (#3200); the diff against `datatables_refactor_phase1_user_accounts` contains only Phase 2 changes. Awaiting manual sign-off before Phase 3.
