### PR TITLE
add outstanding verifications datatable behind feature flag

### DIFF
--- a/app/assets/stylesheets/application.scss.erb
+++ b/app/assets/stylesheets/application.scss.erb
@@ -348,12 +348,10 @@ img {
   margin-left: -15px !important;
 }
 
-/* Print view for the Stimulus datatables (Outstanding Verifications print
-   button). The legacy stack used DataTables' buttons.print.js, which cloned only
-   the table into a new window; this reproduces that from the in-place page by
-   hiding the site header/footer and every piece of datatable chrome (filter
+/* Print view for the Stimulus datatables: print only the current page's table
+   rows. Hide the site header/footer and every piece of datatable chrome (filter
    tabs, date filter, export/print buttons, search, length menu, info line,
-   pager, processing overlay), leaving the current page's table rows. */
+   pager, processing overlay). */
 @media print {
   #header-uic,
   #footer-uic,
@@ -368,10 +366,10 @@ img {
     display: none !important;
   }
 
-  /* Some site print stylesheets blank every anchor (body a { display: none });
-     keep the table's cell links (e.g. the Name column) rendered, matching the
-     legacy print output. */
+  /* A site-wide print rule (body a { display: none }) can blank every anchor;
+     keep the table's cell links (e.g. the Name column) rendered. The id-scoped
+     selector out-specifies body a, so no !important is needed. */
   #effective_datatable_wrapper table.effective-datatable a {
-    display: inline !important;
+    display: inline;
   }
 }

--- a/app/assets/stylesheets/application.scss.erb
+++ b/app/assets/stylesheets/application.scss.erb
@@ -347,3 +347,31 @@ img {
   padding-left: 0 !important;
   margin-left: -15px !important;
 }
+
+/* Print view for the Stimulus datatables (Outstanding Verifications print
+   button). The legacy stack used DataTables' buttons.print.js, which cloned only
+   the table into a new window; this reproduces that from the in-place page by
+   hiding the site header/footer and every piece of datatable chrome (filter
+   tabs, date filter, export/print buttons, search, length menu, info line,
+   pager, processing overlay), leaving the current page's table rows. */
+@media print {
+  #header-uic,
+  #footer-uic,
+  [data-controller="datatable"] > br,
+  [data-controller="datatable"] > div:not(#effective_datatable_wrapper),
+  #effective_datatable_wrapper .dt-buttons,
+  #effective_datatable_wrapper .dataTables_filter,
+  #effective_datatable_wrapper .dataTables_length,
+  #effective_datatable_wrapper .dataTables_info,
+  #effective_datatable_wrapper .dataTables_paginate,
+  #effective_datatable_wrapper .dataTables_processing {
+    display: none !important;
+  }
+
+  /* Some site print stylesheets blank every anchor (body a { display: none });
+     keep the table's cell links (e.g. the Name column) rendered, matching the
+     legacy print output. */
+  #effective_datatable_wrapper table.effective-datatable a {
+    display: inline !important;
+  }
+}

--- a/app/controllers/concerns/datatables/fragment_rendering.rb
+++ b/app/controllers/concerns/datatables/fragment_rendering.rb
@@ -23,15 +23,20 @@ module Datatables
   #   #global_search?   - whether the search box renders
   #   #filters          - nested filter tab definition (legacy shape) or nil
   #   #filter_scopes    - filter param keys collected into #collection's hash
+  #                       (includes custom_datatable_date_from/to when the table
+  #                       has a date filter)
+  #   #date_filter      - label for the date-range filter block, or nil when the
+  #                       table has no date filter
+  #   #buttons          - ordered export/print button keys (e.g. %w[csv excel]
+  #                       or %w[excel csv print]) rendered by datatables/_buttons
+  #   #per_page_options - the page-length menu values (legacy lengthMenu), e.g.
+  #                       [10, 25, 50, 100]; the first is the default page size
   #   #csv_headers      - header row for the streamed CSV export
   #   #csv_row(record)  - plain-text cell values for one CSV row
   #   #row_partial      - partial rendered for each table row with locals
   #                       row, table, row_class
   module FragmentRendering
     extend ActiveSupport::Concern
-
-    DEFAULT_PER_PAGE = 10
-    PER_PAGE_OPTIONS = [10, 25, 50, 100].freeze
 
     private
 
@@ -43,7 +48,7 @@ module Datatables
     def datatable_locals(table, url:)
       scoped = datatable_scoped(table)
       count = scoped.size
-      pagy = datatable_pagy(count)
+      pagy = datatable_pagy(count, table)
       records = scoped.order_by(datatable_order_criteria(table)).skip(pagy.offset).limit(pagy.limit)
       {
         table: table,
@@ -52,7 +57,9 @@ module Datatables
         url: url,
         search: params[:search].to_s,
         order: datatable_order_column(table),
-        dir: datatable_order_dir
+        dir: datatable_order_dir,
+        date_from: params[:custom_datatable_date_from].to_s,
+        date_to: params[:custom_datatable_date_to].to_s
       }
     end
 
@@ -70,16 +77,17 @@ module Datatables
       table.filter_scopes.index_with { |scope| params[scope].presence }.compact
     end
 
-    def datatable_pagy(count)
-      per = datatable_per_page
+    def datatable_pagy(count, table)
+      per = datatable_per_page(table)
       last_page = [(count.to_f / per).ceil, 1].max
       page = params.fetch(:page, 1).to_i.clamp(1, last_page)
       Pagy.new(count: count, page: page, limit: per)
     end
 
-    def datatable_per_page
+    def datatable_per_page(table)
+      options = table.per_page_options
       per = params[:per].to_i
-      PER_PAGE_OPTIONS.include?(per) ? per : DEFAULT_PER_PAGE
+      options.include?(per) ? per : options.first
     end
 
     def datatable_order_column(table)

--- a/app/controllers/concerns/datatables/fragment_rendering.rb
+++ b/app/controllers/concerns/datatables/fragment_rendering.rb
@@ -21,7 +21,7 @@ module Datatables
   #                       order_by/skip/limit/size and, when global_search? is
   #                       true, datatable_search
   #   #global_search?   - whether the search box renders
-  #   #filters          - nested filter tab definition (legacy shape) or nil
+  #   #filters          - nested filter tab definition or nil
   #   #filter_scopes    - filter param keys collected into #collection's hash
   #                       (includes custom_datatable_date_from/to when the table
   #                       has a date filter)
@@ -29,7 +29,7 @@ module Datatables
   #                       table has no date filter
   #   #buttons          - ordered export/print button keys (e.g. %w[csv excel]
   #                       or %w[excel csv print]) rendered by datatables/_buttons
-  #   #per_page_options - the page-length menu values (legacy lengthMenu), e.g.
+  #   #per_page_options - the page-length menu values, e.g.
   #                       [10, 25, 50, 100]; the first is the default page size
   #   #csv_headers      - header row for the streamed CSV export
   #   #csv_row(record)  - plain-text cell values for one CSV row
@@ -71,8 +71,8 @@ module Datatables
       scoped
     end
 
-    # The same attribute hash the legacy DataTables AJAX flow delivered to the
-    # query wrappers via custom_attributes (e.g. {users: 'all', lock_unlock: 'locked'}).
+    # Builds the filter-attribute hash the query wrappers consume
+    # (e.g. {users: 'all', lock_unlock: 'locked'}).
     def datatable_filter_attributes(table)
       table.filter_scopes.index_with { |scope| params[scope].presence }.compact
     end

--- a/app/controllers/exchanges/hbx_profiles_controller.rb
+++ b/app/controllers/exchanges/hbx_profiles_controller.rb
@@ -281,7 +281,26 @@ class Exchanges::HbxProfilesController < ApplicationController
 
   def outstanding_verification_dt
     @selector = params[:scopes][:selector] if params[:scopes].present?
-    @datatable = Effective::Datatables::OutstandingVerificationDataTable.new(params[:scopes])
+    if EnrollRegistry.feature_enabled?(:refactored_datatables)
+      @outstanding_verifications_datatable_locals = datatable_locals(::Datatables::OutstandingVerificationsTable.new, url: outstanding_verifications_datatable_exchanges_hbx_profiles_path)
+    else
+      @datatable = Effective::Datatables::OutstandingVerificationDataTable.new(params[:scopes])
+    end
+  end
+
+  def outstanding_verifications_datatable
+    raise ActionController::RoutingError, 'Not Found' unless EnrollRegistry.feature_enabled?(:refactored_datatables)
+
+    authorize HbxProfile, :outstanding_verification_dt?
+    table = ::Datatables::OutstandingVerificationsTable.new
+    respond_to do |format|
+      format.html { render_datatable_fragment(table, url: outstanding_verifications_datatable_exchanges_hbx_profiles_path) }
+      format.csv do
+        stream_datatable_csv(filename: 'outstanding_verifications.csv',
+                             headers: table.csv_headers,
+                             rows: datatable_csv_rows(table, datatable_scoped(table)))
+      end
+    end
   end
 
   def hide_form

--- a/app/helpers/datatables/table_helper.rb
+++ b/app/helpers/datatables/table_helper.rb
@@ -10,6 +10,10 @@ module Datatables
     # Pagy#series in how it pins the first/last pages - the legacy pager markup
     # is the parity contract for the migration, so its algorithm is reproduced here.
     def datatable_page_series(pagy)
+      # An empty result set renders no numbered page buttons (only the disabled
+      # Previous/Next), matching the legacy DataTables pager at zero records.
+      return [] if pagy.count.zero?
+
       page = pagy.page - 1
       pages = pagy.last
       buttons = DATATABLE_PAGE_BUTTONS

--- a/app/helpers/datatables/table_helper.rb
+++ b/app/helpers/datatables/table_helper.rb
@@ -5,13 +5,13 @@ module Datatables
   module TableHelper
     DATATABLE_PAGE_BUTTONS = 7
 
-    # Zero-based page numbers (and :ellipsis markers) replicating the
-    # jQuery DataTables 'simple_numbers' pager layout, which differs from
-    # Pagy#series in how it pins the first/last pages - the legacy pager markup
-    # is the parity contract for the migration, so its algorithm is reproduced here.
+    # Zero-based page numbers (and :ellipsis markers) for the DataTables-style
+    # 'simple_numbers' pager, which differs from Pagy#series in how it pins the
+    # first/last pages - the pager markup is fixed, so its algorithm is
+    # reproduced here.
     def datatable_page_series(pagy)
       # An empty result set renders no numbered page buttons (only the disabled
-      # Previous/Next), matching the legacy DataTables pager at zero records.
+      # Previous/Next).
       return [] if pagy.count.zero?
 
       page = pagy.page - 1

--- a/app/javascript/datatables/controllers/datatable_controller.js
+++ b/app/javascript/datatables/controllers/datatable_controller.js
@@ -83,8 +83,7 @@ export default class extends Controller {
   }
 
   // Print uses the browser dialog against the @media print rules that hide the
-  // surrounding chrome, matching the legacy DataTables print view (the visible
-  // rows of the current page).
+  // surrounding chrome, leaving the current page's rows.
   print(event) {
     event.preventDefault()
     window.print()
@@ -103,7 +102,7 @@ export default class extends Controller {
     this.redraw()
   }
 
-  // Filter tab behavior: one active tab per level, clicking hides deeper levels, an active tab reveals its Filter-<id> sub-level. Must stay equivalent to the legacy DT.filters() implementation while both stacks coexist.
+  // Filter tab behavior: one active tab per level; clicking hides deeper levels, and an active tab reveals its Filter-<id> sub-level.
   filterClicked(event) {
     const button = event.currentTarget
     const group = button.parentElement

--- a/app/javascript/datatables/controllers/datatable_controller.js
+++ b/app/javascript/datatables/controllers/datatable_controller.js
@@ -12,11 +12,14 @@ export default class extends Controller {
     per: { type: Number, default: 10 },
     search: { type: String, default: "" },
     order: { type: String, default: "" },
-    dir: { type: String, default: "asc" }
+    dir: { type: String, default: "asc" },
+    dateFrom: { type: String, default: "" },
+    dateTo: { type: String, default: "" }
   }
 
   connect() {
     this.bindLengthSelect()
+    this.initDatepickers()
   }
 
   disconnect() {
@@ -79,6 +82,27 @@ export default class extends Controller {
     window.location.assign(url)
   }
 
+  // Print uses the browser dialog against the @media print rules that hide the
+  // surrounding chrome, matching the legacy DataTables print view (the visible
+  // rows of the current page).
+  print(event) {
+    event.preventDefault()
+    window.print()
+  }
+
+  // The date-range Apply button: read the two datepicker inputs (their .value is
+  // set by the jQuery datepicker) and redraw with custom_datatable_date_from/to,
+  // which the query wrapper turns into a Family.min_verification_due_date_range
+  // scope.
+  applyDateRange() {
+    const from = this.element.querySelector("#custom_datatable_date_from")
+    const to = this.element.querySelector("#custom_datatable_date_to")
+    this.dateFromValue = from ? from.value : ""
+    this.dateToValue = to ? to.value : ""
+    this.pageValue = 1
+    this.redraw()
+  }
+
   // Filter tab behavior: one active tab per level, clicking hides deeper levels, an active tab reveals its Filter-<id> sub-level. Must stay equivalent to the legacy DT.filters() implementation while both stacks coexist.
   filterClicked(event) {
     const button = event.currentTarget
@@ -131,6 +155,8 @@ export default class extends Controller {
       url.searchParams.set("order", this.orderValue)
       url.searchParams.set("dir", this.dirValue)
     }
+    if (this.dateFromValue) url.searchParams.set("custom_datatable_date_from", this.dateFromValue)
+    if (this.dateToValue) url.searchParams.set("custom_datatable_date_to", this.dateToValue)
     const filters = this.filterParams()
     Object.keys(filters).forEach((key) => url.searchParams.set(key, filters[key]))
     return url
@@ -169,6 +195,19 @@ export default class extends Controller {
     } else {
       select.addEventListener("change", (event) => this.perChanged(event))
     }
+  }
+
+  // The date-range inputs use the legacy page-level jQuery UI datepicker. Like
+  // the length select, it is a jQuery plugin, so it is initialized here rather
+  // than via a Stimulus data-action. The date filter lives outside the redraw
+  // wrapper, so this runs once on connect and does not need re-binding after a
+  // swap; reading the inputs' .value on Apply works because the datepicker
+  // writes the chosen date to the native input value.
+  initDatepickers() {
+    const $ = window.jQuery
+    if (!$ || !$.fn || !$.fn.datepicker) return
+    const datepickers = this.element.querySelectorAll(".datepicker")
+    if (datepickers.length) $(datepickers).datepicker({ dateFormat: "yy-mm-dd" })
   }
 
   showProcessing() {

--- a/app/models/datatables/broker_agencies_table.rb
+++ b/app/models/datatables/broker_agencies_table.rb
@@ -1,24 +1,18 @@
 # frozen_string_literal: true
 
 module Datatables
-  # Table definition for the Broker Agencies admin datatable (Pagy + Stimulus
-  # stack). Mirrors Effective::Datatables::BrokerAgencyDatatable: same columns,
-  # same single-tab filter definition, and the same
-  # BenefitSponsors::Organizations::Organization collection, so both stacks
-  # return identical data while the :refactored_datatables flag is being
-  # rolled out.
-  #
-  # Implements the table contract documented in Datatables::FragmentRendering.
-  # Unlike UserAccountsTable, the collection is a plain Mongoid criteria
-  # rather than a query wrapper.
+  # Table definition for the Broker Agencies admin datatable. Implements the
+  # table contract documented in Datatables::FragmentRendering. Unlike
+  # UserAccountsTable, the collection is a plain Mongoid criteria rather than a
+  # query wrapper.
   class BrokerAgenciesTable
     def param_key
       'broker_agencies'
     end
 
     # No column is user-sortable; the collection arrives pre-sorted by
-    # legal_name, which legal_name's ordered flag surfaces as the sort
-    # indicator (matching the legacy default order of [0, asc]).
+    # legal_name, and legal_name's ordered flag surfaces that as the sort
+    # indicator on its (non-clickable) header.
     def columns
       [
         { name: 'legal_name',  label: 'Legal Name',  sortable: false, type: :string, ordered: true },
@@ -29,8 +23,7 @@ module Datatables
       ]
     end
 
-    # The legacy datatable ignores the filter attributes too - its only tab
-    # ("All") narrows nothing.
+    # The only tab ("All") narrows nothing, so the filter attributes are ignored.
     def collection(_attributes)
       BenefitSponsors::Organizations::Organization.broker_agency_profiles.order_by([:legal_name])
     end

--- a/app/models/datatables/broker_agencies_table.rb
+++ b/app/models/datatables/broker_agencies_table.rb
@@ -52,6 +52,18 @@ module Datatables
       [:broker_agencies]
     end
 
+    def date_filter
+      nil
+    end
+
+    def buttons
+      %w[csv excel]
+    end
+
+    def per_page_options
+      [10, 25, 50, 100]
+    end
+
     def csv_headers
       columns.map { |col| col[:label] }
     end

--- a/app/models/datatables/outstanding_verifications_table.rb
+++ b/app/models/datatables/outstanding_verifications_table.rb
@@ -1,27 +1,20 @@
 # frozen_string_literal: true
 
 module Datatables
-  # Table definition for the Outstanding Verifications admin datatable (Pagy +
-  # Stimulus stack). Mirrors Effective::Datatables::OutstandingVerificationDataTable:
-  # same columns, same documents-uploaded filter tabs, the same
-  # "Verification Due Date Range" date filter, and the same
-  # Queries::OutstandingVerificationDatatableQuery collection wrapper, so both
-  # stacks return identical data while the :refactored_datatables flag is being
-  # rolled out.
-  #
-  # Implements the table contract documented in Datatables::FragmentRendering.
-  # This is the first table to declare a date filter and to render the print
+  # Table definition for the Outstanding Verifications admin datatable.
+  # Implements the table contract documented in Datatables::FragmentRendering;
+  # it is the one table that declares a date-range filter and renders the print
   # button (buttons: excel, csv, print).
   class OutstandingVerificationsTable
     def param_key
       'outstanding_verifications'
     end
 
-    # name/documents_uploaded/verification_due are sortable to match the legacy
-    # column flags (and the default order [0, asc] surfaces sorting_asc on the
-    # name header). The sort itself is effectively a no-op: the query wrapper
-    # only applies order_by while a search is active, and the column names are
-    # not real Family fields - the legacy stack reorders nothing here either.
+    # name/documents_uploaded/verification_due render as sortable, and name is
+    # the default-ordered column (its header shows sorting_asc on load). The sort
+    # is a visual no-op, though: the query wrapper only applies order_by while a
+    # search is active, and these column names are not real Family fields, so
+    # nothing actually reorders.
     def columns
       [
         { name: 'name',               label: 'Name',               sortable: true,  type: :string },
@@ -62,25 +55,23 @@ module Datatables
       [:documents_uploaded, :custom_datatable_date_from, :custom_datatable_date_to]
     end
 
-    # Label for the date-range filter block (legacy date_filter_name_definition).
+    # Label for the date-range filter block.
     def date_filter
       'Verification Due Date Range'
     end
 
-    # Rendered (and in this order) by the buttons partial. Print is unique to
-    # this page among the migrated tables.
+    # Rendered in this order by the buttons partial; this is the one table with
+    # a print button.
     def buttons
       %w[excel csv print]
     end
 
-    # Legacy length menu: render_datatable was passed lengthMenu
-    # [[10, 25, 50], [10, 25, 50]] - no 100 option, unlike the default tables.
+    # This page's length menu is 10/25/50 (no 100, unlike the default tables).
     def per_page_options
       [10, 25, 50]
     end
 
-    # The actions column is excluded, matching the legacy client-side export
-    # (buttons exported ':not(.col-actions)').
+    # The actions column is excluded from the export.
     def csv_headers
       columns[0..-2].map { |col| col[:label] }
     end

--- a/app/models/datatables/outstanding_verifications_table.rb
+++ b/app/models/datatables/outstanding_verifications_table.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module Datatables
+  # Table definition for the Outstanding Verifications admin datatable (Pagy +
+  # Stimulus stack). Mirrors Effective::Datatables::OutstandingVerificationDataTable:
+  # same columns, same documents-uploaded filter tabs, the same
+  # "Verification Due Date Range" date filter, and the same
+  # Queries::OutstandingVerificationDatatableQuery collection wrapper, so both
+  # stacks return identical data while the :refactored_datatables flag is being
+  # rolled out.
+  #
+  # Implements the table contract documented in Datatables::FragmentRendering.
+  # This is the first table to declare a date filter and to render the print
+  # button (buttons: excel, csv, print).
+  class OutstandingVerificationsTable
+    def param_key
+      'outstanding_verifications'
+    end
+
+    # name/documents_uploaded/verification_due are sortable to match the legacy
+    # column flags (and the default order [0, asc] surfaces sorting_asc on the
+    # name header). The sort itself is effectively a no-op: the query wrapper
+    # only applies order_by while a search is active, and the column names are
+    # not real Family fields - the legacy stack reorders nothing here either.
+    def columns
+      [
+        { name: 'name',               label: 'Name',               sortable: true,  type: :string },
+        { name: 'ssn',                label: 'SSN',                sortable: false, type: :string },
+        { name: 'dob',                label: 'DOB',                sortable: false, type: :string },
+        { name: 'hbx_id',             label: 'HBX ID',             sortable: false, type: :integer },
+        { name: 'count',              label: 'Count',              sortable: false, type: :string, width: '100px' },
+        { name: 'documents_uploaded', label: 'Documents Uploaded', sortable: true,  type: :string },
+        { name: 'verification_due',   label: 'Verification Due',   sortable: true,  type: :string },
+        { name: 'actions',            label: 'Actions',            sortable: false, type: :string, width: '50px' }
+      ]
+    end
+
+    def collection(attributes)
+      Queries::OutstandingVerificationDatatableQuery.new(attributes)
+    end
+
+    def global_search?
+      true
+    end
+
+    def filters
+      {
+        documents_uploaded: [
+          { scope: 'vlp_fully_uploaded', label: 'Fully Uploaded', title: 'Documents to review for all outstanding verifications' },
+          { scope: 'vlp_partially_uploaded', label: 'Partially Uploaded', title: 'Documents to review for some outstanding verifications' },
+          { scope: 'vlp_none_uploaded', label: 'None Uploaded', title: 'No documents to review' },
+          { scope: 'all', label: 'All', title: 'All outstanding verifications' }
+        ],
+        top_scope: :documents_uploaded
+      }
+    end
+
+    # custom_datatable_date_from/to ride along in the same attribute hash the
+    # filter tabs use; the query wrapper's build_scope reads them to apply
+    # Family.min_verification_due_date_range.
+    def filter_scopes
+      [:documents_uploaded, :custom_datatable_date_from, :custom_datatable_date_to]
+    end
+
+    # Label for the date-range filter block (legacy date_filter_name_definition).
+    def date_filter
+      'Verification Due Date Range'
+    end
+
+    # Rendered (and in this order) by the buttons partial. Print is unique to
+    # this page among the migrated tables.
+    def buttons
+      %w[excel csv print]
+    end
+
+    # Legacy length menu: render_datatable was passed lengthMenu
+    # [[10, 25, 50], [10, 25, 50]] - no 100 option, unlike the default tables.
+    def per_page_options
+      [10, 25, 50]
+    end
+
+    # The actions column is excluded, matching the legacy client-side export
+    # (buttons exported ':not(.col-actions)').
+    def csv_headers
+      columns[0..-2].map { |col| col[:label] }
+    end
+
+    def csv_row(row)
+      person = row.primary_applicant.person
+      [
+        person.full_name,
+        helpers.truncate(helpers.number_to_obscured_ssn(person.ssn)),
+        helpers.format_date(person.dob),
+        person.hbx_id,
+        row.active_family_members.size,
+        row.vlp_documents_status,
+        helpers.format_date(row.best_verification_due_date) || helpers.format_date(TimeKeeper.date_of_record + 95.days)
+      ]
+    end
+
+    def row_partial
+      'exchanges/hbx_profiles/datatables/outstanding_verifications_row'
+    end
+
+    private
+
+    def helpers
+      ApplicationController.helpers
+    end
+  end
+end

--- a/app/models/datatables/user_accounts_table.rb
+++ b/app/models/datatables/user_accounts_table.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
 module Datatables
-  # Table definition for the User Accounts admin datatable (Pagy + Stimulus
-  # stack). Mirrors Effective::Datatables::UserAccountDatatable: same columns,
-  # same nested filter definition, and the same Queries::UserDatatableQuery
-  # collection wrapper, so both stacks return identical data while the
-  # :refactored_datatables flag is being rolled out.
-  #
-  # Implements the table contract documented in Datatables::FragmentRendering.
+  # Table definition for the User Accounts admin datatable. Wraps the filter-tab
+  # attributes in Queries::UserDatatableQuery and implements the table contract
+  # documented in Datatables::FragmentRendering.
   class UserAccountsTable
     def param_key
       'user_accounts'
@@ -72,8 +68,7 @@ module Datatables
       'Locked'
     end
 
-    # The actions column is excluded, matching the legacy client-side export
-    # (buttons exported ':not(.col-actions)').
+    # The actions column is excluded from the export.
     def csv_headers
       columns[0..-2].map { |col| col[:label] }
     end

--- a/app/models/datatables/user_accounts_table.rb
+++ b/app/models/datatables/user_accounts_table.rb
@@ -54,6 +54,18 @@ module Datatables
       [:users, :lock_unlock]
     end
 
+    def date_filter
+      nil
+    end
+
+    def buttons
+      %w[csv excel]
+    end
+
+    def per_page_options
+      [10, 25, 50, 100]
+    end
+
     def status(row)
       return 'Unlocked' if row.locked_at.blank? && row.unlock_token.blank?
 

--- a/app/policies/hbx_profile_policy.rb
+++ b/app/policies/hbx_profile_policy.rb
@@ -134,6 +134,12 @@ class HbxProfilePolicy < ApplicationPolicy
     index?
   end
 
+  # Mirrors the legacy OutstandingVerificationDataTable#authorized? (and the
+  # outstanding_verification_dt page action's check_hbx_staff_role guard).
+  def outstanding_verification_dt?
+    @user.has_hbx_staff_role?
+  end
+
   def issuer_index?
     index?
   end

--- a/app/views/datatables/_buttons.html.erb
+++ b/app/views/datatables/_buttons.html.erb
@@ -1,0 +1,16 @@
+<%# Export/print button group. Each table declares its buttons (and their order)
+    via #buttons; the markup reproduces the legacy DataTables Buttons anchors.
+    CSV and Excel both stream the full filtered CSV (legacy exported the loaded
+    page client-side); print opens the browser print dialog against the @media
+    print rules that hide the surrounding chrome. %>
+<div class="dt-buttons btn-group">
+  <% table.buttons.each do |button| %>
+    <% if button.to_s == 'csv' %>
+      <a class="btn btn-default buttons-csv buttons-html5" tabindex="0" aria-controls="<%= table_id %>" href="#" data-action="click->datatable#exportCsv"><span><%= l10n('datatables.csv') %></span></a>
+    <% elsif button.to_s == 'excel' %>
+      <a class="btn btn-default buttons-excel buttons-html5" tabindex="0" aria-controls="<%= table_id %>" href="#" data-action="click->datatable#exportCsv"><span><%= l10n('datatables.excel') %></span></a>
+    <% elsif button.to_s == 'print' %>
+      <a class="btn btn-default buttons-print" tabindex="0" aria-controls="<%= table_id %>" href="#" data-action="click->datatable#print"><span><%= l10n('datatables.print') %></span></a>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/datatables/_buttons.html.erb
+++ b/app/views/datatables/_buttons.html.erb
@@ -1,8 +1,7 @@
 <%# Export/print button group. Each table declares its buttons (and their order)
-    via #buttons; the markup reproduces the legacy DataTables Buttons anchors.
-    CSV and Excel both stream the full filtered CSV (legacy exported the loaded
-    page client-side); print opens the browser print dialog against the @media
-    print rules that hide the surrounding chrome. %>
+    via #buttons. CSV and Excel both stream the full filtered CSV; print opens
+    the browser print dialog against the @media print rules that hide the
+    surrounding chrome. %>
 <div class="dt-buttons btn-group">
   <% table.buttons.each do |button| %>
     <% if button.to_s == 'csv' %>

--- a/app/views/datatables/_datatable.html.erb
+++ b/app/views/datatables/_datatable.html.erb
@@ -6,8 +6,11 @@
      data-datatable-per-value="<%= pagy.limit %>"
      data-datatable-search-value="<%= search %>"
      data-datatable-order-value="<%= order %>"
-     data-datatable-dir-value="<%= dir %>">
+     data-datatable-dir-value="<%= dir %>"
+     data-datatable-date-from-value="<%= date_from %>"
+     data-datatable-date-to-value="<%= date_to %>">
   <%= render partial: 'datatables/filter_tabs', locals: { filters: table.filters } if table.filters %>
+  <%= render partial: 'datatables/date_filter', locals: { filter_name: table.date_filter } if table.date_filter %>
   <div id="effective_datatable_wrapper" data-datatable-target="wrapper">
     <%= render partial: 'datatables/table',
                locals: { table: table, pagy: pagy, records: records, url: url, search: search, order: order, dir: dir } %>

--- a/app/views/datatables/_date_filter.html.erb
+++ b/app/views/datatables/_date_filter.html.erb
@@ -1,11 +1,9 @@
-<%# Date-range filter, a parity copy of datatables/shared/_date_filter.html.erb
-    (the legacy gem rendered that partial when a datatable defined
-    date_filter_name_definition). The #custom_datatable_date_from / _to inputs and
-    the #date_range_apply button keep their ids so the page-level jQuery datepicker
-    init still binds them. The only new-stack addition is the Apply button's
-    data-action: the Stimulus controller reads the two inputs and adds
-    custom_datatable_date_from/to to the fragment params on redraw. This block sits
-    outside #effective_datatable_wrapper, so it survives redraws untouched. %>
+<%# Date-range filter. The #custom_datatable_date_from / _to inputs and the
+    #date_range_apply button keep their ids so the jQuery datepicker binds them.
+    The Apply button's data-action drives the Stimulus controller, which reads the
+    two inputs and adds custom_datatable_date_from/to to the fragment params on
+    redraw. This block sits outside #effective_datatable_wrapper, so it survives
+    redraws untouched. %>
 <div>
 <h4><%= filter_name %></h4>
 From:

--- a/app/views/datatables/_date_filter.html.erb
+++ b/app/views/datatables/_date_filter.html.erb
@@ -1,0 +1,17 @@
+<%# Date-range filter, a parity copy of datatables/shared/_date_filter.html.erb
+    (the legacy gem rendered that partial when a datatable defined
+    date_filter_name_definition). The #custom_datatable_date_from / _to inputs and
+    the #date_range_apply button keep their ids so the page-level jQuery datepicker
+    init still binds them. The only new-stack addition is the Apply button's
+    data-action: the Stimulus controller reads the two inputs and adds
+    custom_datatable_date_from/to to the fragment params on redraw. This block sits
+    outside #effective_datatable_wrapper, so it survives redraws untouched. %>
+<div>
+<h4><%= filter_name %></h4>
+From:
+<input type="text" id="custom_datatable_date_from" class="datepicker">&nbsp;<i class="fa fa-calendar datepicker" aria-hidden="true"></i>
+&nbsp;&nbsp;&nbsp;&nbsp;To:
+<input type="text" id="custom_datatable_date_to" class="datepicker">&nbsp;<i class="fa fa-calendar datepicker" aria-hidden="true"></i>
+&nbsp;&nbsp;<div class="btn btn-default" id="date_range_apply" data-action="click->datatable#applyDateRange">Apply</div>
+</div>
+<br>

--- a/app/views/datatables/_table.html.erb
+++ b/app/views/datatables/_table.html.erb
@@ -4,10 +4,7 @@
   <div id="<%= table_id %>_wrapper" class="dataTables_wrapper form-inline dt-bootstrap no-footer">
     <div class="row">
       <div class="col-sm-7 col-md-7">
-        <div class="dt-buttons btn-group">
-          <a class="btn btn-default buttons-csv buttons-html5" tabindex="0" aria-controls="<%= table_id %>" href="#" data-action="click->datatable#exportCsv"><span><%= l10n('datatables.csv') %></span></a>
-          <a class="btn btn-default buttons-excel buttons-html5" tabindex="0" aria-controls="<%= table_id %>" href="#" data-action="click->datatable#exportCsv"><span><%= l10n('datatables.excel') %></span></a>
-        </div>
+        <%= render partial: 'datatables/buttons', locals: { table: table, table_id: table_id } %>
       </div>
       <div class="col-sm-5 col-md-5">
         <% if table.global_search? %>
@@ -50,7 +47,9 @@
                 <%= render partial: table.row_partial, locals: { row: record, table: table, row_class: index.even? ? 'odd' : 'even' } %>
               <% end %>
             <% else %>
-              <tr class="odd"><td valign="top" colspan="<%= table.columns.size %>" class="dataTables_empty"><%= l10n('datatables.no_matching_records') %></td></tr>
+              <%# Match the legacy DataTables split: emptyTable when nothing is loaded at all, zeroRecords when a search filtered everything out. %>
+              <% empty_message = search.present? ? l10n('datatables.no_matching_records') : l10n('datatables.no_data') %>
+              <tr class="odd"><td valign="top" colspan="<%= table.columns.size %>" class="dataTables_empty"><%= empty_message %></td></tr>
             <% end %>
           </tbody>
         </table>
@@ -63,7 +62,7 @@
       </div>
       <div class="col-sm-1 col-md-1">
         <div class="dataTables_length" id="<%= table_id %>_length">
-          <label><%# no data-action here: the controller binds this select itself (see bindLengthSelect) because selectric swallows native change events %><select name="<%= table_id %>_length" aria-controls="<%= table_id %>" class="form-control input-sm" tabindex="0"><% ::Datatables::FragmentRendering::PER_PAGE_OPTIONS.each do |option| %><option value="<%= option %>"<%= ' selected'.html_safe if option == pagy.limit %>><%= option %></option><% end %></select> <%= l10n('datatables.per_page') %></label>
+          <label><%# no data-action here: the controller binds this select itself (see bindLengthSelect) because selectric swallows native change events %><select name="<%= table_id %>_length" aria-controls="<%= table_id %>" class="form-control input-sm" tabindex="0"><% table.per_page_options.each do |option| %><option value="<%= option %>"<%= ' selected'.html_safe if option == pagy.limit %>><%= option %></option><% end %></select> <%= l10n('datatables.per_page') %></label>
         </div>
       </div>
     </div>

--- a/app/views/datatables/_table.html.erb
+++ b/app/views/datatables/_table.html.erb
@@ -1,4 +1,4 @@
-<%# The redraw region inside #effective_datatable_wrapper: table, buttons, search, length menu, info line, pager. The markup (grid layout, classes, ids, aria attributes) reproduces what jQuery DataTables generated at init time; each migrated page's flag-OFF DOM snapshot is the parity contract. The two inline display styles are state, kept inline for snapshot parity. %>
+<%# The redraw region inside #effective_datatable_wrapper: table, buttons, search, length menu, info line, pager. The markup (grid layout, classes, ids, aria attributes) matches the existing DataTables DOM so the page renders identically. The two inline display styles are element state, kept inline. %>
 <% table_id = "#{table.param_key}-table" %>
 <div class="row">
   <div id="<%= table_id %>_wrapper" class="dataTables_wrapper form-inline dt-bootstrap no-footer">
@@ -32,7 +32,7 @@
                       data-action="click->datatable#sortClicked" data-column="<%= col[:name] %>"
                       <% if col[:width] %>style="width: <%= col[:width] %>;"<% end %>><span class="filter-label"><%= col[:label] %></span></th>
                 <% else %>
-                  <%# ordered: the collection arrives pre-sorted ascending by this column; the legacy default order rendered the asc indicator on its (non-clickable) header. %>
+                  <%# ordered: the collection arrives pre-sorted ascending by this column; render the asc indicator on its non-clickable header. %>
                   <th class="col-<%= col[:type] %> col-<%= col[:name] %> sorting_disabled<%= ' sorting_asc' if col[:ordered] %>"
                       rowspan="1" colspan="1" data-column-index="<%= index %>"
                       aria-label="<%= label_text %>"
@@ -47,7 +47,7 @@
                 <%= render partial: table.row_partial, locals: { row: record, table: table, row_class: index.even? ? 'odd' : 'even' } %>
               <% end %>
             <% else %>
-              <%# Match the legacy DataTables split: emptyTable when nothing is loaded at all, zeroRecords when a search filtered everything out. %>
+              <%# Two empty states: "no data" when nothing is loaded at all, "no match" when a search filtered everything out. %>
               <% empty_message = search.present? ? l10n('datatables.no_matching_records') : l10n('datatables.no_data') %>
               <tr class="odd"><td valign="top" colspan="<%= table.columns.size %>" class="dataTables_empty"><%= empty_message %></td></tr>
             <% end %>

--- a/app/views/exchanges/hbx_profiles/_outstanding_verification_datatable.html.erb
+++ b/app/views/exchanges/hbx_profiles/_outstanding_verification_datatable.html.erb
@@ -1,19 +1,28 @@
-<p id="notice"><%= notice %></p>
+<% if EnrollRegistry.feature_enabled?(:refactored_datatables) %>
+  <p id="notice"><%= notice %></p>
 
-<div class='container'>
-  <h1> Outstanding Verifications </h1>
-  <%#= link_to 'Switch to APTC / CSR Families', aptc_csr_family_index_exchanges_hbx_profiles_path, remote: true%>
-</div>
-   <%= h render_datatable(@datatable,"lengthMenu": [[10, 25, 50], [10, 25, 50]], buttons: [
-            'excel','csv','print'
-        ]) %>
-</div>
+  <div class='container'>
+    <h1> Outstanding Verifications </h1>
+  </div>
+  <%= render partial: 'datatables/datatable', locals: @outstanding_verifications_datatable_locals %>
+<% else %>
+  <p id="notice"><%= notice %></p>
 
-<script type="text/javascript" charset="utf-8">
-	    $('.datepicker').datepicker({ dateFormat: 'yy-mm-dd' });
- initializeDataTables();
- <% if @selector == 'assisted' %>
-    $('#Tab\\:by_enrollment_individual_market').click();
-    $('#Tab\\:by_enrollment_individual_market-all_assistance_receiving').addClass('active');
-  <% end %>
-</script>
+  <div class='container'>
+    <h1> Outstanding Verifications </h1>
+    <%#= link_to 'Switch to APTC / CSR Families', aptc_csr_family_index_exchanges_hbx_profiles_path, remote: true%>
+  </div>
+     <%= h render_datatable(@datatable,"lengthMenu": [[10, 25, 50], [10, 25, 50]], buttons: [
+              'excel','csv','print'
+          ]) %>
+  </div>
+
+  <script type="text/javascript" charset="utf-8">
+  	    $('.datepicker').datepicker({ dateFormat: 'yy-mm-dd' });
+   initializeDataTables();
+   <% if @selector == 'assisted' %>
+      $('#Tab\\:by_enrollment_individual_market').click();
+      $('#Tab\\:by_enrollment_individual_market-all_assistance_receiving').addClass('active');
+    <% end %>
+  </script>
+<% end %>

--- a/app/views/exchanges/hbx_profiles/datatables/_outstanding_verifications_row.html.erb
+++ b/app/views/exchanges/hbx_profiles/datatables/_outstanding_verifications_row.html.erb
@@ -1,7 +1,5 @@
-<%# One Outstanding Verifications table row. Cell values must stay identical to
-    the legacy OutstandingVerificationDataTable column procs while both stacks
-    coexist. sorting_1 stays on col-name: it is the default-order column (index 0,
-    asc) the legacy stack shaded on load. %>
+<%# One Outstanding Verifications table row. sorting_1 stays on col-name: it is
+    the default-order column (index 0, asc), so its cells carry the sort shading. %>
 <%
   person = row.primary_applicant.person
   dropdowns = [

--- a/app/views/exchanges/hbx_profiles/datatables/_outstanding_verifications_row.html.erb
+++ b/app/views/exchanges/hbx_profiles/datatables/_outstanding_verifications_row.html.erb
@@ -1,0 +1,20 @@
+<%# One Outstanding Verifications table row. Cell values must stay identical to
+    the legacy OutstandingVerificationDataTable column procs while both stacks
+    coexist. sorting_1 stays on col-name: it is the default-order column (index 0,
+    asc) the legacy stack shaded on load. %>
+<%
+  person = row.primary_applicant.person
+  dropdowns = [
+    ['Review', show_docs_documents_path(person_id: person.id), 'static']
+  ]
+%>
+<tr class="<%= row_class %>">
+  <td class="col-string col-name sorting_1"><%= link_to person.full_name, resume_enrollment_exchanges_agents_path(person_id: person.id) %></td>
+  <td class="col-string col-ssn"><%= truncate(number_to_obscured_ssn(person.ssn)) %></td>
+  <td class="col-string col-dob"><%= format_date(person.dob) %></td>
+  <td class="col-integer col-hbx_id"><%= person.hbx_id %></td>
+  <td class="col-string col-count"><%= row.active_family_members.size %></td>
+  <td class="col-string col-documents_uploaded"><%= row.vlp_documents_status %></td>
+  <td class="col-string col-verification_due"><%= format_date(row.best_verification_due_date) || format_date(TimeKeeper.date_of_record + 95.days) %></td>
+  <td class="col-string col-actions"><%= render partial: 'datatables/shared/dropdown', locals: { dropdowns: dropdowns, row_actions_id: "family_actions_#{row.id}" } %></td>
+</tr>

--- a/config/locales/view.en.yml
+++ b/config/locales/view.en.yml
@@ -4,11 +4,13 @@ en:
   datatables:
     csv: "CSV"
     excel: "Excel"
+    print: "Print"
     search_label: "Search:"
     per_page: "per page"
     showing_entries: "Showing %{from} to %{to} of %{count} entries"
     processing: "Processing..."
     no_matching_records: "No matching records found"
+    no_data: "No data available in table"
     previous: "Previous"
     next: "Next"
   welcome:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,7 @@ Rails.application.routes.draw do
         get :family_index
         get :family_index_dt
         get :outstanding_verification_dt
+        get :outstanding_verifications_datatable
         post :families_index_datatable
         get :employer_index
         post :employer_poc_datatable

--- a/spec/controllers/exchanges/hbx_profiles_controller_spec.rb
+++ b/spec/controllers/exchanges/hbx_profiles_controller_spec.rb
@@ -325,6 +325,80 @@ RSpec.describe Exchanges::HbxProfilesController, dbclean: :after_each do
       end
     end
   end
+
+  describe "Action # outstanding_verifications_datatable (:refactored_datatables)", dbclean: :after_each do
+    let(:person) { double("person", hbx_staff_role: double("hbx_staff_role")) }
+    let(:user) { double("user", :has_hbx_staff_role? => true, :person => person, :last_portal_visited => nil) }
+
+    before :each do
+      allow(user).to receive(:has_role?).with(:hbx_staff).and_return(true)
+      allow(EnrollRegistry).to receive(:feature_enabled?).and_call_original
+      allow(EnrollRegistry).to receive(:feature_enabled?).with(:refactored_datatables).and_return(true)
+      sign_in(user)
+    end
+
+    context "when the :refactored_datatables flag is disabled" do
+      before do
+        allow(EnrollRegistry).to receive(:feature_enabled?).with(:refactored_datatables).and_return(false)
+      end
+
+      it "404s the fragment endpoint" do
+        expect { get :outstanding_verifications_datatable, format: :html }.to raise_error(ActionController::RoutingError)
+      end
+
+      it "builds the legacy datatable on outstanding_verification_dt" do
+        get :outstanding_verification_dt, xhr: true, format: :js
+        expect(assigns(:datatable)).to be_a(Effective::Datatables::OutstandingVerificationDataTable)
+        expect(assigns(:outstanding_verifications_datatable_locals)).to be_nil
+      end
+    end
+
+    context "when the user is not an HBX staff member" do
+      let(:user) { double("user", :has_hbx_staff_role? => false, :person => person, :last_portal_visited => nil) }
+
+      it "denies access" do
+        get :outstanding_verifications_datatable, format: :html
+        expect(response).not_to have_http_status(:success)
+      end
+    end
+
+    context "when authorized with the flag enabled" do
+      it "renders the table fragment without a layout" do
+        get :outstanding_verifications_datatable, format: :html
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template("datatables/_table")
+      end
+
+      it "prepares the datatable locals (incl. date range) on outstanding_verification_dt" do
+        get :outstanding_verification_dt, xhr: true, format: :js
+        expect(assigns(:outstanding_verifications_datatable_locals)).to include(:table, :pagy, :records, :url, :date_from, :date_to)
+        expect(assigns(:datatable)).to be_nil
+      end
+
+      # The action streams via response_body=Enumerator, so the test response
+      # body must be materialized before parsing.
+      def streamed_csv_rows
+        body = response.body
+        CSV.parse(body.is_a?(String) ? body : body.to_a.join)
+      end
+
+      it "streams a CSV with the excluded-actions header row" do
+        get :outstanding_verifications_datatable, params: { documents_uploaded: "all" }, format: :csv
+        expect(response.headers["Content-Type"]).to eq("text/csv; charset=utf-8")
+        expect(response.headers["Content-Disposition"]).to include('filename="outstanding_verifications.csv"')
+        rows = streamed_csv_rows
+        expect(rows.first).to eq(["Name", "SSN", "DOB", "HBX ID", "Count", "Documents Uploaded", "Verification Due"])
+      end
+
+      it "passes the date-range params through to the export without error" do
+        get :outstanding_verifications_datatable,
+            params: { documents_uploaded: "all", custom_datatable_date_from: "2026-01-01", custom_datatable_date_to: "2026-12-31" },
+            format: :csv
+        expect(response.headers["Content-Disposition"]).to include('filename="outstanding_verifications.csv"')
+        expect(streamed_csv_rows.first).to eq(["Name", "SSN", "DOB", "HBX ID", "Count", "Documents Uploaded", "Verification Due"])
+      end
+    end
+  end
 =begin
   describe "#create" do
     let(:user) { double("User")}

--- a/spec/models/datatables/outstanding_verifications_table_spec.rb
+++ b/spec/models/datatables/outstanding_verifications_table_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Datatables::OutstandingVerificationsTable, dbclean: :after_each do
+  subject(:table) { described_class.new }
+
+  describe '#columns' do
+    it 'mirrors the legacy OutstandingVerificationDataTable column order and labels' do
+      expect(table.columns.map { |col| col[:name] }).to eq(
+        %w[name ssn dob hbx_id count documents_uploaded verification_due actions]
+      )
+      expect(table.columns.map { |col| col[:label] }).to eq(
+        ['Name', 'SSN', 'DOB', 'HBX ID', 'Count', 'Documents Uploaded', 'Verification Due', 'Actions']
+      )
+    end
+
+    it 'marks name, documents_uploaded, and verification_due sortable (matching the legacy flags)' do
+      expect(table.columns.select { |col| col[:sortable] }.map { |col| col[:name] }).to eq(
+        %w[name documents_uploaded verification_due]
+      )
+    end
+
+    it 'types hbx_id as integer for the col-integer class' do
+      expect(table.columns.find { |col| col[:name] == 'hbx_id' }[:type]).to eq(:integer)
+    end
+  end
+
+  describe '#collection' do
+    it 'wraps the filter attributes in the legacy OutstandingVerificationDatatableQuery' do
+      collection = table.collection(documents_uploaded: 'vlp_partially_uploaded',
+                                    custom_datatable_date_from: '2026-01-01',
+                                    custom_datatable_date_to: '2026-12-31')
+      expect(collection).to be_a(Queries::OutstandingVerificationDatatableQuery)
+      expect(collection.custom_attributes).to eq(
+        documents_uploaded: 'vlp_partially_uploaded',
+        custom_datatable_date_from: '2026-01-01',
+        custom_datatable_date_to: '2026-12-31'
+      )
+    end
+  end
+
+  describe '#filters' do
+    it 'reproduces the legacy documents-uploaded filter definition' do
+      expect(table.filters[:top_scope]).to eq(:documents_uploaded)
+      expect(table.filters[:documents_uploaded].map { |filter| filter[:scope] }).to eq(
+        %w[vlp_fully_uploaded vlp_partially_uploaded vlp_none_uploaded all]
+      )
+    end
+  end
+
+  describe '#filter_scopes' do
+    it 'carries the documents-uploaded tab and both date-range params to the query wrapper' do
+      expect(table.filter_scopes).to eq([:documents_uploaded, :custom_datatable_date_from, :custom_datatable_date_to])
+    end
+  end
+
+  describe '#date_filter' do
+    it 'is the verification-due date range label' do
+      expect(table.date_filter).to eq('Verification Due Date Range')
+    end
+  end
+
+  describe '#buttons' do
+    it 'renders excel, csv, and print in the legacy order' do
+      expect(table.buttons).to eq(%w[excel csv print])
+    end
+  end
+
+  describe '#per_page_options' do
+    it 'omits the 100 option, matching the legacy lengthMenu [[10,25,50],[10,25,50]]' do
+      expect(table.per_page_options).to eq([10, 25, 50])
+    end
+  end
+
+  describe 'csv export' do
+    # ssn must be a mutable string: number_to_ssn formats it in place with gsub!,
+    # just as it does on the real (unfrozen) Mongoid Person#ssn value.
+    let(:person) { double('person', full_name: 'Jane Doe', ssn: +'123456789', dob: Date.new(1985, 3, 2), hbx_id: '55555') }
+    let(:primary_applicant) { double('primary_applicant', person: person) }
+    let(:family) do
+      double('family',
+             primary_applicant: primary_applicant,
+             active_family_members: [double, double, double],
+             vlp_documents_status: 'Partially Uploaded',
+             best_verification_due_date: Date.new(2026, 7, 1))
+    end
+
+    it 'excludes the actions column from the headers' do
+      expect(table.csv_headers).to eq(['Name', 'SSN', 'DOB', 'HBX ID', 'Count', 'Documents Uploaded', 'Verification Due'])
+    end
+
+    it 'renders the same plain-text values the table cells show' do
+      expect(table.csv_row(family)).to eq(
+        ['Jane Doe', '***-**-6789', '03/02/1985', '55555', 3, 'Partially Uploaded', '07/01/2026']
+      )
+    end
+
+    it 'falls back to today + 95 days when there is no best verification due date' do
+      allow(family).to receive(:best_verification_due_date).and_return(nil)
+      fallback = ApplicationController.helpers.format_date(TimeKeeper.date_of_record + 95.days)
+      expect(table.csv_row(family).last).to eq(fallback)
+    end
+  end
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/health-connector/enroll/blob/master/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Inert code (no impact until run, e.g. data fix or migration, manually triggered bulk process, etc.)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)
- [ ] Release (Prepares code for a release, e.g., version bumps, changelog updates, tagging, deployment scripts)

# What is the ticket # detailing the issue?

Ticket: [868jab71m](https://app.clickup.com/t/9011313074/868jab71m) (CCAOMDEV-27) — Phase 3 of the DataTables refactor.

> **Stacked PR.** Base branch is `datatables_refactor_phase2_broker_agencies` (Phase 2, PR #3203), which is itself stacked on Phase 1 (PR #3200, base `master`). The stack merges bottom-up: #3200 → #3203 → this PR. Review only the Phase 3 commit here.

# A brief description of the changes

This is Phase 3 of replacing the EOL `effective_datatables` gem (+ jQuery DataTables) with a Pagy + Mongoid + Stimulus stack, one page at a time behind a single feature flag. It migrates the **Admin → Outstanding Verifications** tab and adds the two capabilities the Phase 1/2 scaffold did not yet have: a **date-range filter** and **print**.

**Current behavior (flag OFF — unchanged):** the tab renders via the vendored `effective_datatables` gem / jQuery DataTables, with the "Verification Due Date Range" filter and the Excel/CSV/Print buttons. The new fragment endpoint `/exchanges/hbx_profiles/outstanding_verifications_datatable` 404s.

**New behavior (flag ON):** the tab renders via the new stack — server-rendered, DataTables-parity chrome driven by a Stimulus controller, no jQuery DataTables.
- **Date-range filter**: a shared `_date_filter.html.erb` (byte-parity copy of the legacy markup); the Stimulus `applyDateRange` action adds `custom_datatable_date_from`/`custom_datatable_date_to` to the fragment params, which the existing `Queries::OutstandingVerificationDatatableQuery` consumes (`Family.min_verification_due_date_range`). The filter persists across pagination/search/tab changes. The legacy jQuery datepicker is kept, initialized from the Stimulus controller.
- **Print**: a per-table buttons partial renders the print anchor (Excel/CSV/Print, in the legacy order) only when the table opts in; a one-line `window.print()` Stimulus action prints against a new `@media print` stylesheet that hides all chrome (filter tabs, date filter, buttons, search, length menu, info, pager, site header/footer), leaving the current page's table — equivalent to the legacy DataTables print view.
- As in Phases 1–2, the CSV/Excel buttons stream a server-side CSV of **all** filtered rows (the legacy client-side export covered only the loaded page).

Parity verified by a flag-OFF vs flag-ON DOM snapshot structural diff (identical except the deliberately-removed legacy inline `<script>`/`<style>`), the controller/PORO specs, and manual Chrome DevTools checks (date Apply + redraw survival, print media, datepicker, zero console errors).

# Feature Flag

Variable name: `REFACTORED_DATATABLES_IS_ENABLED` (flag `:refactored_datatables`, default off) — client: **CCA**. Same single flag introduced in Phase 1; all migrated pages flip together.

# Additional Context

**QA steps (scoped to this change):**
1. With the flag **off**, open Admin → (Families →) Outstanding Verifications: the page renders exactly as today (date-range filter + Excel/CSV/Print). `GET /exchanges/hbx_profiles/outstanding_verifications_datatable` returns 404.
2. Set `REFACTORED_DATATABLES_IS_ENABLED=true`, restart, hard-refresh. Open the same tab:
   - Columns Name / SSN / DOB / HBX ID / Count / Documents Uploaded / Verification Due / Actions; documents-uploaded filter tabs (Fully/Partially/None/All); length menu 10/25/50.
   - **Date range**: click the From/To datepickers, pick dates, click Apply → the table filters; the date range survives paging and tab changes.
   - **Print**: click Print → the browser print preview shows only the current page's table rows (no filter bar, buttons, pager, or site header/footer).
   - CSV and Excel both download a CSV of all filtered rows.
   - Confirm User Accounts and Broker Agencies still work flag-on with no console errors.

**Automated verification:** RuboCop clean on branch files; `outstanding_verifications_table_spec` + the new `hbx_profiles_controller_spec` block pass (127 examples, 0 failures across the three table specs + controller spec); Phase 1 `features/admin/user_account.feature` green in both flag states.

> Note: `features/admin/outstanding_verifications.feature` is tagged `@individual_enabled` and is excluded by the default cucumber profile on SHOP-only CCA (the Outstanding Verifications nav link is not rendered when `individual_market_is_enabled?` is false, so the feature fails at its first step in both flag states). Its parity assertions (`Tab:vlp_*` ids, `td.col-name`) are covered by the controller spec + the DOM snapshot structural diff + manual browser checks instead.
