### PR TITLE
update renewal eligibility logic for off-cycle date changes

### DIFF
--- a/components/benefit_sponsors/app/models/benefit_sponsors/benefit_sponsorships/aca_shop_benefit_sponsorship_service.rb
+++ b/components/benefit_sponsors/app/models/benefit_sponsors/benefit_sponsorships/aca_shop_benefit_sponsorship_service.rb
@@ -128,11 +128,15 @@ module BenefitSponsors
       notify(RENEWAL_EMPLOYER_CARRIER_DROP_EVENT, {employer_id: benefit_sponsorship.profile.hbx_id, event_name: RENEWAL_APPLICATION_CARRIER_DROP_EVENT_TAG}) unless benefit_sponsorship.is_renewal_transmission_eligible?
     end
 
-    # TODO: Need to verify is_renewing? logic for off-cycle renewals
     def self.set_binder_paid(benefit_sponsorship_ids)
       benefit_sponsorships = ::BenefitSponsors::BenefitSponsorships::BenefitSponsorship.where(:"_id".in => benefit_sponsorship_ids)
       benefit_sponsorships.each do |benefit_sponsorship|
-        benefit_sponsorship.benefit_applications.each { |benefit_application| benefit_application.credit_binder! if (!benefit_application.is_renewing? && benefit_application.may_credit_binder?) }
+        benefit_sponsorship.benefit_applications.each do |benefit_application|
+          # off-cycle date-change renewals have a terminated predecessor, route them through binder_paid like initial apps
+          annual_renewal = benefit_application.is_renewing? &&
+                           (benefit_application.predecessor&.active? || benefit_application.predecessor&.expired?)
+          benefit_application.credit_binder! if !annual_renewal && benefit_application.may_credit_binder?
+        end
       end
     end
 

--- a/components/benefit_sponsors/app/models/benefit_sponsors/benefit_sponsorships/benefit_sponsorship.rb
+++ b/components/benefit_sponsors/app/models/benefit_sponsors/benefit_sponsorships/benefit_sponsorship.rb
@@ -546,8 +546,10 @@ module BenefitSponsors
           start_on_condition = application.start_on.to_date == (application.predecessor.end_on + 1.day).to_date
           state_condition = [:active, :enrollment_eligible].include?(application.aasm_state.to_sym)
           date_condition = application.start_on.to_date >= (TimeKeeper.date_of_record - 1.month).to_date # grace period of one month for late renewal
+          # off-cycle date change renewals have a terminated predecessor, exclude them from the renewal EDI path
+          predecessor_natural_end = application.predecessor.active? || application.predecessor.expired?
 
-          start_on_condition && state_condition && date_condition
+          start_on_condition && state_condition && date_condition && predecessor_natural_end
         else
           false
         end
@@ -629,7 +631,12 @@ module BenefitSponsors
 
     #### TODO FIX Move these methods to domain logic layer
     def is_renewal_transmission_eligible?
-      (renewal_benefit_application.present? && renewal_benefit_application.enrollment_eligible?) || late_renewal_benefit_application.present?
+      renewal_app = renewal_benefit_application
+      # off-cycle date-change apps have a terminated predecessor, they must not fire the renewal EDI event
+      predecessor = renewal_app&.predecessor
+      predecessor_natural_end = predecessor&.active? || predecessor&.expired?
+      annual_renewal_eligible = renewal_app.present? && renewal_app.enrollment_eligible? && predecessor_natural_end
+      annual_renewal_eligible || late_renewal_benefit_application.present?
     end
 
     def is_renewal_carrier_drop?

--- a/components/benefit_sponsors/spec/models/benefit_sponsors/benefit_sponsorships/aca_shop_benefit_sponsorship_service_spec.rb
+++ b/components/benefit_sponsors/spec/models/benefit_sponsors/benefit_sponsorships/aca_shop_benefit_sponsorship_service_spec.rb
@@ -272,5 +272,99 @@ module BenefitSponsors
       end
 
     end
+
+    describe '.set_binder_paid', :dbclean => :after_each do
+      let(:effective_date) { TimeKeeper.date_of_record.next_month.beginning_of_month }
+
+      context "when benefit application is initial (no predecessor)" do
+        let!(:initial_sponsor) do
+          create(
+            :benefit_sponsors_benefit_sponsorship,
+            :with_organization_cca_profile,
+            :with_initial_benefit_application,
+            initial_application_state: :enrollment_closed,
+            default_effective_period: (effective_date..(effective_date + 1.year - 1.day)),
+            site: site
+          )
+        end
+
+        it 'credits binder for initial application' do
+          subject.set_binder_paid([initial_sponsor.id])
+          expect(initial_sponsor.benefit_applications.first.reload.binder_paid?).to be_truthy
+        end
+      end
+
+      context "when benefit application is an annual renewal (predecessor expired)" do
+        let!(:renewal_sponsor) do
+          create(
+            :benefit_sponsors_benefit_sponsorship,
+            :with_organization_cca_profile,
+            :with_renewal_benefit_application,
+            initial_application_state: :active,
+            renewal_application_state: :enrollment_closed,
+            default_effective_period: (effective_date..(effective_date + 1.year - 1.day)),
+            site: site,
+            aasm_state: :active
+          )
+        end
+        let!(:expired_predecessor) do
+          active_application = renewal_sponsor.active_benefit_application
+          expired_application = FactoryBot.create(
+            :benefit_sponsors_benefit_application,
+            benefit_sponsorship: renewal_sponsor,
+            recorded_service_areas: renewal_sponsor.primary_office_service_areas,
+            aasm_state: :expired,
+            default_effective_period: (active_application.start_on - 1.year..active_application.start_on - 1.day)
+          )
+          active_application.predecessor = expired_application
+          active_application.save
+          expired_application
+        end
+
+        before { expired_predecessor }
+
+        it 'does not credit binder for annual renewal application' do
+          renewal_app = renewal_sponsor.renewal_benefit_application
+          subject.set_binder_paid([renewal_sponsor.id])
+          expect(renewal_app.reload.binder_paid?).to be_falsey
+        end
+      end
+
+      context "when benefit application is an off-cycle renewal (predecessor terminated)" do
+        let!(:off_cycle_sponsor) do
+          create(
+            :benefit_sponsors_benefit_sponsorship,
+            :with_organization_cca_profile,
+            :with_renewal_benefit_application,
+            initial_application_state: :active,
+            renewal_application_state: :enrollment_closed,
+            default_effective_period: (effective_date..(effective_date + 1.year - 1.day)),
+            site: site,
+            aasm_state: :active
+          )
+        end
+        let!(:terminated_predecessor) do
+          renewal_application = off_cycle_sponsor.renewal_benefit_application
+          terminated_application = FactoryBot.create(
+            :benefit_sponsors_benefit_application,
+            benefit_sponsorship: off_cycle_sponsor,
+            recorded_service_areas: off_cycle_sponsor.primary_office_service_areas,
+            aasm_state: :terminated,
+            default_effective_period: (renewal_application.start_on - 1.year..renewal_application.start_on - 1.day)
+          )
+          renewal_application.predecessor = terminated_application
+          renewal_application.save
+          terminated_application
+        end
+
+        before { terminated_predecessor }
+
+        it 'credits binder for off-cycle renewal application' do
+          renewal_app = off_cycle_sponsor.renewal_benefit_application
+          subject.set_binder_paid([off_cycle_sponsor.id])
+          expect(renewal_app.reload.binder_paid?).to be_truthy
+        end
+      end
+    end
   end
 end

--- a/components/benefit_sponsors/spec/models/benefit_sponsors/benefit_sponsorships/benefit_sponsorship_spec.rb
+++ b/components/benefit_sponsors/spec/models/benefit_sponsors/benefit_sponsorships/benefit_sponsorship_spec.rb
@@ -1188,6 +1188,92 @@ module BenefitSponsors
           expect(benefit_sponsorship.late_renewal_benefit_application).to eq benefit_sponsorship.renewal_benefit_application
         end
       end
+
+      context "when predecessor is terminated (off-cycle date change)" do
+        let!(:terminated_predecessor) do
+          terminated_application = FactoryBot.create(
+            :benefit_sponsors_benefit_application,
+            benefit_sponsorship: benefit_sponsorship,
+            recorded_service_areas: benefit_sponsorship.primary_office_service_areas,
+            aasm_state: :terminated,
+            default_effective_period: (benefit_sponsorship.active_benefit_application.start_on - 1.year..benefit_sponsorship.active_benefit_application.start_on - 1.day)
+          )
+          active_application = benefit_sponsorship.active_benefit_application
+          active_application.predecessor = terminated_application
+          active_application.save
+          terminated_application
+        end
+
+        before do
+          terminated_predecessor
+          benefit_sponsorship.active_benefit_application.update_attributes(aasm_state: 'enrollment_eligible')
+        end
+
+        it 'should return nil' do
+          expect(benefit_sponsorship.late_renewal_benefit_application).to eq nil
+        end
+      end
+    end
+
+    describe '.is_renewal_transmission_eligible?', :dbclean => :after_each do
+
+      let(:effective_date) { TimeKeeper.date_of_record.next_month.beginning_of_month }
+      let!(:benefit_sponsorship) do
+        create(
+          :benefit_sponsors_benefit_sponsorship,
+          :with_organization_cca_profile,
+          :with_renewal_benefit_application,
+          initial_application_state: :active,
+          renewal_application_state: :enrollment_eligible,
+          default_effective_period: (effective_date..(effective_date + 1.year - 1.day)),
+          site: site,
+          aasm_state: :active
+        )
+      end
+
+      context "when renewal application has an expired predecessor (annual renewal)" do
+        let!(:expired_predecessor) do
+          expired_application = FactoryBot.create(
+            :benefit_sponsors_benefit_application,
+            benefit_sponsorship: benefit_sponsorship,
+            recorded_service_areas: benefit_sponsorship.primary_office_service_areas,
+            aasm_state: :expired,
+            default_effective_period: (benefit_sponsorship.active_benefit_application.start_on - 1.year..benefit_sponsorship.active_benefit_application.start_on - 1.day)
+          )
+          active_application = benefit_sponsorship.active_benefit_application
+          active_application.predecessor = expired_application
+          active_application.save
+          expired_application
+        end
+
+        before { expired_predecessor }
+
+        it 'should return true' do
+          expect(benefit_sponsorship.is_renewal_transmission_eligible?).to be_truthy
+        end
+      end
+
+      context "when renewal application has a terminated predecessor (off-cycle date change)" do
+        let!(:terminated_predecessor) do
+          renewal_application = benefit_sponsorship.renewal_benefit_application
+          terminated_application = FactoryBot.create(
+            :benefit_sponsors_benefit_application,
+            benefit_sponsorship: benefit_sponsorship,
+            recorded_service_areas: benefit_sponsorship.primary_office_service_areas,
+            aasm_state: :terminated,
+            default_effective_period: (renewal_application.start_on - 1.year..renewal_application.start_on - 1.day)
+          )
+          renewal_application.predecessor = terminated_application
+          renewal_application.save
+          terminated_application
+        end
+
+        before { terminated_predecessor }
+
+        it 'should return false' do
+          expect(benefit_sponsorship.is_renewal_transmission_eligible?).to be_falsey
+        end
+      end
     end
 
     describe '.is_potential_off_cycle_employer', dbclean: :after_each do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/health-connector/enroll/blob/master/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Inert code (no impact until run, e.g. data fix or migration, manually triggered bulk process, etc.)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)
- [ ] Release (Prepares code for a release, e.g., version bumps, changelog updates, tagging, deployment scripts)

# What is the ticket # detailing the issue?

Ticket: 
CU: https://app.clickup.com/t/9011313074/868hhtfqh
RM:  https://redmine-app.dchbx.org/issues/113327

# A brief description of the changes

Current behavior:
When an employer changes their renewal date mid-year (off-cycle), the system incorrectly treats the new enrollment as a renewal continuation of the old plan year. 

New behavior:
Off-cycle plan year changes (identified by a terminated predecessor) are now excluded from renewal EDI transmission. This ensures:
- Off-cycle applications with terminated predecessors return false from is_renewal_transmission_eligible?
- New enrollments correctly send ADD messages (via transmit_initial_eligible_event)
- Annual renewals (naturally-ended predecessors: active or expired) continue to send renewal transmissions as before
- Binder credit is now correctly applied to off-cycle applications

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:


# Additional Context
Include any additional context that may be relevant to the peer review process.
