### PR TITLE
add employers datatable to the refactored stack

### DIFF
--- a/app/controllers/concerns/datatables/fragment_rendering.rb
+++ b/app/controllers/concerns/datatables/fragment_rendering.rb
@@ -27,6 +27,22 @@ module Datatables
   #                       has a date filter)
   #   #date_filter      - label for the date-range filter block, or nil when the
   #                       table has no date filter
+  #   #default_order_column - column name whose header shows the sort indicator on
+  #                       load (and which orders the collection when no user sort
+  #                       is active); may name a non-visible field (e.g. created_at)
+  #                       so that no visible header is highlighted
+  #   #column_index_offset - amount added to each column's positional index for the
+  #                       th data-column-index attribute, accounting for any
+  #                       leading non-rendered legacy columns (usually 0)
+  #   #bulk_actions     - ordered bulk-action configs ({label, url, confirm}) for
+  #                       the dropdown prepended into datatables/_buttons; [] when
+  #                       the table has no bulk actions
+  #   #disable_selectric? - whether the Stimulus controller suppresses page-global
+  #                       selectric (true for tables whose row actions inject forms
+  #                       with native selects that must stay reachable)
+  #   #search_column(collection, name, value) - applies a per-column filter (only
+  #                       called for columns declaring a filter:); returns the
+  #                       narrowed collection
   #   #buttons          - ordered export/print button keys (e.g. %w[csv excel]
   #                       or %w[excel csv print]) rendered by datatables/_buttons
   #   #per_page_options - the page-length menu values, e.g.
@@ -59,7 +75,8 @@ module Datatables
         order: datatable_order_column(table),
         dir: datatable_order_dir,
         date_from: params[:custom_datatable_date_from].to_s,
-        date_to: params[:custom_datatable_date_to].to_s
+        date_to: params[:custom_datatable_date_to].to_s,
+        column_filters: datatable_column_filters(table)
       }
     end
 
@@ -68,7 +85,19 @@ module Datatables
     def datatable_scoped(table)
       scoped = table.collection(datatable_filter_attributes(table))
       scoped = scoped.datatable_search(params[:search]) if table.global_search? && params[:search].present?
+      datatable_column_filters(table).each { |name, value| scoped = table.search_column(scoped, name, value) }
       scoped
+    end
+
+    # Active per-column filter values keyed by column name, read from the
+    # columns[<name>]=<value> params the controller adds for filter columns.
+    def datatable_column_filters(table)
+      table.columns.each_with_object({}) do |col, filters|
+        next unless col[:filter]
+
+        value = params.dig(:columns, col[:name])
+        filters[col[:name]] = value if value.present?
+      end
     end
 
     # Builds the filter-attribute hash the query wrappers consume
@@ -92,7 +121,7 @@ module Datatables
 
     def datatable_order_column(table)
       sortable = table.columns.select { |col| col[:sortable] }.map { |col| col[:name] }
-      sortable.include?(params[:order]) ? params[:order] : sortable.first
+      sortable.include?(params[:order]) ? params[:order] : table.default_order_column
     end
 
     def datatable_order_dir

--- a/app/controllers/exchanges/hbx_profiles_controller.rb
+++ b/app/controllers/exchanges/hbx_profiles_controller.rb
@@ -182,7 +182,11 @@ class Exchanges::HbxProfilesController < ApplicationController
     @next_60_day = @next_30_day.next_month
     @next_90_day = @next_60_day.next_month
 
-    @datatable = Effective::Datatables::BenefitSponsorsEmployerDatatable.new
+    if EnrollRegistry.feature_enabled?(:refactored_datatables)
+      @employers_datatable_locals = datatable_locals(::Datatables::EmployersTable.new, url: employers_datatable_exchanges_hbx_profiles_path)
+    else
+      @datatable = Effective::Datatables::BenefitSponsorsEmployerDatatable.new
+    end
 
     respond_to do |format|
       format.js
@@ -192,10 +196,29 @@ class Exchanges::HbxProfilesController < ApplicationController
   def employer_datatable
     # copy the link and open in new tab
     last_visited_url = current_user.try(:last_portal_visited) || root_path if current_user.present?
-    @datatable = Effective::Datatables::BenefitSponsorsEmployerDatatable.new
+    if EnrollRegistry.feature_enabled?(:refactored_datatables)
+      @employers_datatable_locals = datatable_locals(::Datatables::EmployersTable.new, url: employers_datatable_exchanges_hbx_profiles_path)
+    else
+      @datatable = Effective::Datatables::BenefitSponsorsEmployerDatatable.new
+    end
     respond_to do |format|
       format.html { redirect_to(last_visited_url, allow_other_host: true) }
       format.js
+    end
+  end
+
+  def employers_datatable
+    raise ActionController::RoutingError, 'Not Found' unless EnrollRegistry.feature_enabled?(:refactored_datatables)
+
+    authorize HbxProfile, :employer_datatable?
+    table = ::Datatables::EmployersTable.new
+    respond_to do |format|
+      format.html { render_datatable_fragment(table, url: employers_datatable_exchanges_hbx_profiles_path) }
+      format.csv do
+        stream_datatable_csv(filename: 'employers.csv',
+                             headers: table.csv_headers,
+                             rows: datatable_csv_rows(table, datatable_scoped(table)))
+      end
     end
   end
 

--- a/app/javascript/datatables/controllers/bulk_actions_controller.js
+++ b/app/javascript/datatables/controllers/bulk_actions_controller.js
@@ -1,0 +1,133 @@
+import { Controller } from "@hotwired/stimulus"
+import axios from "axios"
+
+// Drives the employer bulk-actions dropdown. The checkbox column, the dropdown,
+// and the processing panel all live inside the wrapper the datatable controller
+// swaps on redraw, so this controller (scoped to the persistent container)
+// listens by event delegation and re-applies row state on every draw rather than
+// holding Stimulus targets.
+const MESSAGE_VISIBLE_MS = 2000
+const ALL_ROLE = "input[data-role='bulk-actions-all']"
+const RESOURCE_ROLE = "input[data-role='bulk-actions-resource']"
+const LINK_SELECTOR = ".buttons-bulk-actions a"
+
+export default class extends Controller {
+  connect() {
+    this.onChange = this.onChange.bind(this)
+    this.onClick = this.onClick.bind(this)
+    this.onDraw = this.refresh.bind(this)
+    this.element.addEventListener("change", this.onChange)
+    this.element.addEventListener("click", this.onClick)
+    this.element.addEventListener("effective-datatable:draw", this.onDraw)
+    this.refresh()
+  }
+
+  disconnect() {
+    this.element.removeEventListener("change", this.onChange)
+    this.element.removeEventListener("click", this.onClick)
+    this.element.removeEventListener("effective-datatable:draw", this.onDraw)
+  }
+
+  onChange(event) {
+    if (event.target.matches(ALL_ROLE)) {
+      this.toggleAll(event.target.checked)
+    } else if (event.target.matches(RESOURCE_ROLE)) {
+      const checkAll = this.element.querySelector(ALL_ROLE)
+      if (checkAll) checkAll.checked = false
+      this.syncButton()
+    }
+  }
+
+  onClick(event) {
+    const link = event.target.closest(LINK_SELECTOR)
+    if (!link || !this.element.contains(link)) return
+    event.preventDefault()
+    // The legacy effective_datatables bulk_actions script (loaded on the page)
+    // also delegates clicks on .buttons-bulk-actions a; stop the event here so
+    // only this controller posts, avoiding a duplicate request.
+    event.stopPropagation()
+    const group = link.closest(".buttons-bulk-actions")
+    if (group) group.classList.remove("open")
+    this.submit(link)
+  }
+
+  // Disable ineligible row checkboxes and sync the dropdown button on the initial
+  // render and after each redraw.
+  refresh() {
+    this.resources().forEach((checkbox) => {
+      if (checkbox.dataset.status === "Ineligible") {
+        checkbox.disabled = true
+        checkbox.classList.add("disabled")
+      }
+    })
+    this.syncButton()
+  }
+
+  toggleAll(checked) {
+    this.resources().forEach((checkbox) => {
+      if (checkbox.dataset.status === "Eligible") checkbox.checked = checked
+    })
+    this.syncButton()
+  }
+
+  syncButton() {
+    const anyChecked = this.resources().some((checkbox) => checkbox.checked)
+    this.element.querySelectorAll(".buttons-bulk-actions button").forEach((button) => {
+      button.disabled = !anyChecked
+    })
+  }
+
+  submit(link) {
+    const url = link.getAttribute("href")
+    const ids = this.resources().filter((checkbox) => checkbox.checked).map((checkbox) => checkbox.value)
+    if (!url || ids.length === 0) return
+
+    const confirmation = link.dataset.confirm
+    if (confirmation && !window.confirm(confirmation)) return
+
+    const title = link.textContent.trim()
+    const button = link.closest(".buttons-bulk-actions").querySelector("button")
+    if (button) button.disabled = true
+    this.showMessage("Processing...")
+
+    axios({
+      method: "POST",
+      url: url,
+      data: { ids: ids },
+      // generate_invoice only responds to format.js; an Accept of */* lets Rails
+      // serve it (and binder_paid's explicit JSON render) without a 406.
+      headers: { "X-CSRF-Token": this.csrfToken(), "Accept": "*/*" }
+    })
+      .then((response) => this.showMessage((response.data && response.data.message) || `Successfully completed ${title} bulk action`))
+      .catch((error) => {
+        const message = (error.response && error.response.data && error.response.data.message) ||
+          `An error occured while attempting ${title} bulk action`
+        this.showMessage(message)
+        window.alert(message)
+      })
+      // Hold the result message briefly, then redraw so refreshed row data
+      // (e.g. the Invoiced? column) is reflected.
+      .finally(() => setTimeout(() => this.requestRedraw(), MESSAGE_VISIBLE_MS))
+  }
+
+  requestRedraw() {
+    const datatable = this.application.getControllerForElementAndIdentifier(this.element, "datatable")
+    if (datatable) datatable.redraw()
+  }
+
+  resources() {
+    return Array.from(this.element.querySelectorAll(RESOURCE_ROLE))
+  }
+
+  showMessage(message) {
+    const processing = this.element.querySelector(".dataTables_processing")
+    if (!processing) return
+    processing.innerHTML = message
+    processing.style.display = "block"
+  }
+
+  csrfToken() {
+    const meta = document.querySelector("meta[name=csrf-token]")
+    return meta ? meta.content : ""
+  }
+}

--- a/app/javascript/datatables/controllers/datatable_controller.js
+++ b/app/javascript/datatables/controllers/datatable_controller.js
@@ -14,11 +14,17 @@ export default class extends Controller {
     order: { type: String, default: "" },
     dir: { type: String, default: "asc" },
     dateFrom: { type: String, default: "" },
-    dateTo: { type: String, default: "" }
+    dateTo: { type: String, default: "" },
+    disableSelectric: { type: Boolean, default: false }
   }
 
   connect() {
+    // Page-global selectric (freebies.js) skips selects while disableSelectric is
+    // set. Tables that inject forms with native selects (the employer Create Plan
+    // Year form) opt out so those selects stay reachable.
+    window.disableSelectric = this.disableSelectricValue
     this.bindLengthSelect()
+    this.bindColumnFilters()
     this.initDatepickers()
   }
 
@@ -137,6 +143,7 @@ export default class extends Controller {
       this.wrapperTarget.innerHTML = await response.text()
       this.applyLegacyDecorations()
       this.bindLengthSelect()
+      this.bindColumnFilters()
       this.element.dispatchEvent(new CustomEvent("effective-datatable:draw", { bubbles: true }))
     } catch (error) {
       this.hideProcessing()
@@ -158,7 +165,16 @@ export default class extends Controller {
     if (this.dateToValue) url.searchParams.set("custom_datatable_date_to", this.dateToValue)
     const filters = this.filterParams()
     Object.keys(filters).forEach((key) => url.searchParams.set(key, filters[key]))
+    this.columnFilterParams().forEach((filter) => url.searchParams.set(`columns[${filter.name}]`, filter.value))
     return url
+  }
+
+  // Per-column select filters contribute columns[<name>]=<value>, omitting any
+  // select left at its no-filter default (data-column-default).
+  columnFilterParams() {
+    return Array.from(this.element.querySelectorAll("#effective_datatable_wrapper select[data-column-name]"))
+      .filter((select) => select.value && select.value !== select.dataset.columnDefault)
+      .map((select) => ({ name: select.dataset.columnName, value: select.value }))
   }
 
   // Walks the active tab chain: each level's active button contributes <group data-scope> = <button data-key> — the same params the query wrappers have always received.
@@ -196,6 +212,28 @@ export default class extends Controller {
     }
   }
 
+  // Per-column filter selects are bound the same way as the length select: they
+  // may be wrapped by selectric (a jQuery plugin whose triggered change events
+  // are invisible to native listeners), so bind via jQuery with a native
+  // fallback, re-binding after each fragment swap.
+  bindColumnFilters() {
+    const selects = this.element.querySelectorAll("#effective_datatable_wrapper select[data-column-name]")
+    if (!selects.length) return
+    const $ = window.jQuery
+    selects.forEach((select) => {
+      if ($) {
+        $(select).off("change.datatable-column").on("change.datatable-column", () => this.columnFilterChanged())
+      } else {
+        select.addEventListener("change", () => this.columnFilterChanged())
+      }
+    })
+  }
+
+  columnFilterChanged() {
+    this.pageValue = 1
+    this.redraw()
+  }
+
   // The date-range inputs use the legacy page-level jQuery UI datepicker. Like
   // the length select, it is a jQuery plugin, so it is initialized here rather
   // than via a Stimulus data-action. The date filter lives outside the redraw
@@ -223,6 +261,7 @@ export default class extends Controller {
   // calls no-op once the legacy scripts are retired.
   applyLegacyDecorations() {
     if (typeof window.semantic_class === "function") window.semantic_class()
+    if (window.disableSelectric) return
     const $ = window.jQuery
     const select = this.element.querySelector(".dataTables_length select")
     if ($ && $.fn && $.fn.selectric && select) $(select).selectric()

--- a/app/models/datatables/broker_agencies_table.rb
+++ b/app/models/datatables/broker_agencies_table.rb
@@ -49,6 +49,24 @@ module Datatables
       nil
     end
 
+    # No column is user-sortable and the collection carries its own legal_name
+    # order, so no header is the active sort.
+    def default_order_column
+      nil
+    end
+
+    def column_index_offset
+      0
+    end
+
+    def bulk_actions
+      []
+    end
+
+    def disable_selectric?
+      false
+    end
+
     def buttons
       %w[csv excel]
     end

--- a/app/models/datatables/employers_table.rb
+++ b/app/models/datatables/employers_table.rb
@@ -1,0 +1,321 @@
+# frozen_string_literal: true
+
+module Datatables
+  # Table definition for the Employers / Employer Invoice admin datatable (both
+  # tabs render this; both back onto BenefitSponsorsEmployerDatatable). Implements
+  # the table contract documented in Datatables::FragmentRendering and adds the
+  # two capabilities the scaffold gained in this phase: bulk actions (the dropdown
+  # in #bulk_actions, the per-row checkbox column) and a per-column select filter
+  # (source_kind, via #search_column).
+  class EmployersTable
+    include Config::AcaModelConcern
+
+    SOURCE_KINDS = ([:all] + BenefitSponsors::BenefitSponsorships::BenefitSponsorship::SOURCE_KINDS).freeze
+
+    # Whitelist of scope/method names a filter attribute is permitted to invoke on
+    # the collection. Filter values arrive in query params, so the collection
+    # method derived from them is checked against this list before send - an
+    # injection guard.
+    ALLOWED_METHODS = %w[
+      benefit_sponsorship_applicant benefit_application_enrolling
+      benefit_application_enrolled employer_attestations
+      all benefit_application_enrolling_initial benefit_application_pending
+      benefit_application_enrolling_initial_oe benefit_application_initial_binder_paid
+      benefit_application_initial_binder_pending benefit_application_enrolling_renewing
+      benefit_application_renewal_pending benefit_application_enrolling_renewing_oe
+      benefit_application_enrolled benefit_application_suspended
+      submitted pending approved denied
+    ].freeze
+
+    FILTER_MAPPINGS = {
+      employers: :filter_by_employers,
+      enrolling: :filter_by_enrolling,
+      enrolled: :filter_by_enrolled,
+      employer_attestations: :filter_by_employer_attestations,
+      upcoming_dates: :filter_by_upcoming_dates,
+      attestations: :filter_by_attestations
+    }.freeze
+
+    def param_key
+      'employers'
+    end
+
+    # Column 0 in the legacy table is a hidden created_at column, so the visible
+    # columns carry data-column-index 1..n; this offset reproduces that numbering.
+    def column_index_offset
+      1
+    end
+
+    # bulk_actions is the checkbox column (its header renders the check-all box).
+    # source_kind carries the only per-column select filter in the app. The
+    # attestation_status column appears only when employer attestations are on,
+    # matching the legacy attestation gating.
+    def columns
+      cols = [
+        { name: 'bulk_actions',    label: '',                 sortable: false, type: :bulk_actions_column, header: :bulk_all },
+        { name: 'legal_name',      label: 'Legal Name',       sortable: false, type: :string },
+        { name: 'fein',            label: 'FEIN',             sortable: false, type: :string },
+        { name: 'hbx_id',          label: 'HBX ID',           sortable: false, type: :integer },
+        { name: 'broker',          label: 'Broker',           sortable: false, type: :string },
+        { name: 'source_kind',     label: 'Source Kind',      sortable: false, type: :string, filter: { collection: SOURCE_KINDS, selected: 'all' } },
+        { name: 'plan_year_state', label: 'Plan Year State',  sortable: false, type: :string },
+        { name: 'effective_date',  label: 'Effective Date',   sortable: true,  type: :string },
+        { name: 'invoiced?',       label: 'Invoiced?',        sortable: false, type: :string }
+      ]
+      cols << { name: 'attestation_status', label: 'Attestation Status', sortable: false, type: :string } if employer_attestation_is_enabled?
+      cols << { name: 'actions', label: 'Actions', sortable: false, type: :string, width: '50px' }
+      cols
+    end
+
+    # The collection is BenefitSponsorship.unscoped narrowed by the active filter
+    # tab(s); created_at is its default order (no visible column is the active
+    # sort) so the header carries no sort direction on load.
+    def collection(attributes)
+      benefit_sponsorships = BenefitSponsors::BenefitSponsorships::BenefitSponsorship.unscoped
+      @attributes = attributes
+      FILTER_MAPPINGS.each do |attribute, method|
+        benefit_sponsorships = send(method, benefit_sponsorships) if attributes[attribute].present?
+      end
+      benefit_sponsorships
+    end
+
+    def default_order_column
+      'created_at'
+    end
+
+    def global_search?
+      true
+    end
+
+    # Applies the source_kind select filter. "all" means no column filter.
+    def search_column(collection, column_name, value)
+      return collection unless column_name.to_s == 'source_kind' && value.present? && value != 'all'
+
+      collection.datatable_search_for_source_kind(value.to_sym)
+    end
+
+    def filters
+      next_30_day = TimeKeeper.date_of_record.next_month.beginning_of_month
+      next_60_day = next_30_day.next_month
+      thirty = next_30_day.strftime('%m/%d/%Y')
+      sixty = next_60_day.strftime('%m/%d/%Y')
+
+      filters = {
+        enrolling_renewing: [
+          { scope: 'all', label: 'All' },
+          { scope: 'benefit_application_renewal_pending', label: 'Application Pending' },
+          { scope: 'benefit_application_enrolling_renewing_oe', label: 'Open Enrollment' }
+        ],
+        enrolling_initial: [
+          { scope: 'all', label: 'All' },
+          { scope: 'benefit_application_pending', label: 'Application Pending' },
+          { scope: 'benefit_application_enrolling_initial_oe', label: 'Open Enrollment' },
+          { scope: 'benefit_application_initial_binder_paid', label: 'Binder Paid' },
+          { scope: 'benefit_application_initial_binder_pending', label: 'Binder Pending' }
+        ],
+        enrolled: [
+          { scope: 'benefit_application_enrolled', label: 'All' },
+          { scope: 'benefit_application_suspended', label: 'Suspended' }
+        ],
+        upcoming_dates: [
+          { scope: thirty, label: thirty },
+          { scope: sixty, label: sixty }
+        ],
+        enrolling: [
+          { scope: 'benefit_application_enrolling', label: 'All' },
+          { scope: 'benefit_application_enrolling_initial', label: 'Initial', subfilter: :enrolling_initial },
+          { scope: 'benefit_application_enrolling_renewing', label: 'Renewing / Converting', subfilter: :enrolling_renewing },
+          { scope: 'benefit_application_enrolling', label: 'Upcoming Dates', subfilter: :upcoming_dates }
+        ],
+        attestations: [
+          { scope: 'employer_attestations', label: 'All' },
+          { scope: 'submitted', label: 'Submitted' },
+          { scope: 'pending', label: 'Pending' },
+          { scope: 'approved', label: 'Approved' },
+          { scope: 'denied', label: 'Denied' }
+        ],
+        employers: [
+          { scope: 'all', label: 'All' },
+          { scope: 'benefit_sponsorship_applicant', label: 'Applicants' },
+          { scope: 'benefit_application_enrolling', label: 'Enrolling', subfilter: :enrolling },
+          { scope: 'benefit_application_enrolled', label: 'Enrolled', subfilter: :enrolled }
+        ],
+        top_scope: :employers
+      }
+      filters[:employers] << { scope: 'employer_attestations', label: 'Employer Attestations', subfilter: :attestations } if employer_attestation_is_enabled?
+      filters
+    end
+
+    # Every tab scope the filter bar can emit, collected into the attribute hash
+    # #collection consumes. attestation_status rides along with the attestation
+    # sub-tabs.
+    def filter_scopes
+      [:employers, :enrolling, :enrolling_initial, :enrolling_renewing, :enrolled,
+       :upcoming_dates, :attestations, :employer_attestations, :attestation_status]
+    end
+
+    def date_filter
+      nil
+    end
+
+    # The two bulk actions surfaced in the dropdown, in declared order. Each posts
+    # the selected benefit-sponsorship ids to its existing endpoint.
+    def bulk_actions
+      [
+        { label: 'Generate Invoice', url: Rails.application.routes.url_helpers.generate_invoice_exchanges_hbx_profiles_path, confirm: 'Generate Invoices?' },
+        { label: 'Mark Binder Paid', url: Rails.application.routes.url_helpers.binder_paid_exchanges_hbx_profiles_path, confirm: 'Mark Binder Paid?' }
+      ]
+    end
+
+    def buttons
+      %w[csv excel]
+    end
+
+    def per_page_options
+      [10, 25, 50, 100]
+    end
+
+    # The row-action dropdowns inject forms (e.g. Create Plan Year) whose native
+    # selects must stay reachable, so page-global selectric is suppressed here.
+    def disable_selectric?
+      true
+    end
+
+    # The bulk-actions and actions columns are excluded from the export.
+    def csv_headers
+      data_columns.map { |col| col[:label] }
+    end
+
+    def csv_row(row)
+      employer_profile = row.organization.employer_profile
+      benefit_application = row.dt_display_benefit_application
+      values = [
+        row.organization.legal_name,
+        row.organization.fein,
+        row.organization.hbx_id,
+        employer_profile&.active_broker_agency_legal_name,
+        row.source_kind.to_s.humanize,
+        (helpers.benefit_application_summarized_state(benefit_application) if benefit_application.present?),
+        (benefit_application.effective_period.min&.strftime('%m/%d/%Y') if benefit_application.present?),
+        employer_profile&.current_month_invoice.present?
+      ]
+      values << employer_profile&.attestation_status if employer_attestation_is_enabled?
+      values
+    end
+
+    def row_partial
+      'exchanges/hbx_profiles/datatables/employers_row'
+    end
+
+    # Dropdown link type for the per-row Generate Invoice action.
+    def generate_invoice_link_type(employer_profile)
+      employer_profile.current_month_invoice.present? ? 'disabled' : 'post_ajax'
+    end
+
+    # Dropdown link type for the per-row Force Publish action: shown only when a
+    # draft application exists, its publish window is open, and the user is
+    # allowed.
+    def force_publish_link_type(benefit_sponsorship, allow)
+      draft_application = latest_draft_benefit_application(benefit_sponsorship)
+      draft_application.present? && business_policy_accepted?(draft_application) && allow ? 'ajax' : 'hide'
+    end
+
+    private
+
+    def data_columns
+      columns.reject { |col| %w[bulk_actions actions].include?(col[:name]) }
+    end
+
+    def latest_draft_benefit_application(benefit_sponsorship)
+      draft_apps = benefit_sponsorship.benefit_applications.draft_state
+      draft_apps.present? ? draft_apps.last : ''
+    end
+
+    def business_policy_accepted?(draft_application)
+      TimeKeeper.date_of_record > draft_application.last_day_to_publish && TimeKeeper.date_of_record < draft_application.start_on
+    end
+
+    def helpers
+      ApplicationController.helpers
+    end
+
+    def call_safe_method(object, method)
+      return object unless method.present? && ALLOWED_METHODS.include?(method)
+
+      if object.respond_to?(method)
+        object.public_send(method)
+      else
+        Rails.logger.warn("Attempted to call method that does not respond: #{method}")
+        object
+      end
+    end
+
+    def filter_by_employers(benefit_sponsorships)
+      return benefit_sponsorships unless @attributes[:employers].present? && !['all'].include?(@attributes[:employers])
+
+      call_safe_method(benefit_sponsorships, @attributes[:employers])
+    end
+
+    def filter_by_enrolling(benefit_sponsorships)
+      return benefit_sponsorships unless @attributes[:enrolling_status].present?
+
+      enrolling_scope_map = {
+        'active' => :active_enrolling,
+        'renewing' => :renewing_enrolling,
+        'terminated' => :terminated_enrolling
+      }
+
+      scope = enrolling_scope_map[@attributes[:enrolling_status]]
+      if scope && benefit_sponsorships.respond_to?(scope)
+        benefit_sponsorships.send(scope)
+      else
+        Rails.logger.warn("Invalid enrolling status: #{@attributes[:enrolling_status]}")
+        benefit_sponsorships
+      end
+    end
+
+    def filter_by_enrolled(benefit_sponsorships)
+      @attributes[:enrolled].present? ? call_safe_method(benefit_sponsorships, @attributes[:enrolled]) : benefit_sponsorships
+    end
+
+    def filter_by_employer_attestations(benefit_sponsorships)
+      return benefit_sponsorships unless @attributes[:employer_attestations].present?
+
+      benefit_sponsorships = call_safe_method(benefit_sponsorships, @attributes[:employer_attestations])
+
+      status_scope_map = {
+        'submitted' => :submitted,
+        'pending' => :pending,
+        'approved' => :approved,
+        'denied' => :denied
+      }
+
+      if @attributes[:attestation_status].present?
+        scope = status_scope_map[@attributes[:attestation_status]]
+        benefit_sponsorships = benefit_sponsorships.send(scope) if scope && benefit_sponsorships.respond_to?(scope)
+      end
+
+      benefit_sponsorships
+    end
+
+    def filter_by_upcoming_dates(benefit_sponsorships)
+      return benefit_sponsorships unless @attributes[:upcoming_dates].present?
+
+      date = parse_date(@attributes[:upcoming_dates])
+      date ? benefit_sponsorships.effective_date_begin_on(date) : benefit_sponsorships
+    end
+
+    def filter_by_attestations(benefit_sponsorships)
+      return benefit_sponsorships unless @attributes[:attestations].present? && @attributes[:attestations] != 'employer_attestations'
+
+      benefit_sponsorships.attestations_by_kind(@attributes[:attestations])
+    end
+
+    def parse_date(date_str)
+      Date.strptime(date_str, '%m/%d/%Y')
+    rescue StandardError => e
+      Rails.logger.warn("Date parsing error: #{e.message}")
+      nil
+    end
+  end
+end

--- a/app/models/datatables/outstanding_verifications_table.rb
+++ b/app/models/datatables/outstanding_verifications_table.rb
@@ -60,6 +60,22 @@ module Datatables
       'Verification Due Date Range'
     end
 
+    def default_order_column
+      'name'
+    end
+
+    def column_index_offset
+      0
+    end
+
+    def bulk_actions
+      []
+    end
+
+    def disable_selectric?
+      false
+    end
+
     # Rendered in this order by the buttons partial; this is the one table with
     # a print button.
     def buttons

--- a/app/models/datatables/user_accounts_table.rb
+++ b/app/models/datatables/user_accounts_table.rb
@@ -54,6 +54,22 @@ module Datatables
       nil
     end
 
+    def default_order_column
+      'name'
+    end
+
+    def column_index_offset
+      0
+    end
+
+    def bulk_actions
+      []
+    end
+
+    def disable_selectric?
+      false
+    end
+
     def buttons
       %w[csv excel]
     end

--- a/app/policies/hbx_profile_policy.rb
+++ b/app/policies/hbx_profile_policy.rb
@@ -140,6 +140,13 @@ class HbxProfilePolicy < ApplicationPolicy
     @user.has_hbx_staff_role?
   end
 
+  # Mirrors the legacy BenefitSponsorsEmployerDatatable#authorized? (and the
+  # employer_datatable / employer_invoice page actions' check_hbx_staff_role
+  # guard); gates the employers fragment/CSV endpoint.
+  def employer_datatable?
+    @user.has_hbx_staff_role?
+  end
+
   def issuer_index?
     index?
   end

--- a/app/views/datatables/_bulk_actions_header.html.erb
+++ b/app/views/datatables/_bulk_actions_header.html.erb
@@ -1,0 +1,6 @@
+<%# Check-all checkbox rendered inside the bulk-actions column header, after the
+    (empty) label. data-role="bulk-actions-all" is what the bulk-actions Stimulus
+    controller binds to; checking it selects every eligible row checkbox. The
+    interaction-* decoration classes are applied client-side and are not rendered
+    here. %>
+<br><div class="input boolean optional datatable_filter_<%= col[:name] %>"><input autocomplete="off" value="0" type="hidden"><label class="checkbox"><input value="1" autocomplete="off" data-column-name="<%= col[:name] %>" data-column-index="<%= column_index %>" data-role="bulk-actions-all" class="boolean optional" type="checkbox" id="datatable_filter_<%= col[:name] %>"></label></div>

--- a/app/views/datatables/_buttons.html.erb
+++ b/app/views/datatables/_buttons.html.erb
@@ -3,6 +3,17 @@
     the browser print dialog against the @media print rules that hide the
     surrounding chrome. %>
 <div class="dt-buttons btn-group">
+  <% if table.bulk_actions.present? %>
+    <%# Prepended inside .dt-buttons per the DOM parity contract. The button is disabled until a row is checked (the bulk-actions controller toggles it); each link posts the selected ids to its endpoint. %>
+    <div class="btn-group buttons-bulk-actions">
+      <button aria-haspopup="" class="btn btn-default dropdown-toggle" data-toggle="dropdown" disabled="disabled" type="button"><%= l10n('datatables.bulk_actions') %><span class="caret"></span></button>
+      <ul class="dropdown-menu">
+        <% table.bulk_actions.each do |action| %>
+          <li><a data-confirm="<%= action[:confirm] %>" data-no-turbolink="true" href="<%= action[:url] %>"><%= action[:label] %></a></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
   <% table.buttons.each do |button| %>
     <% if button.to_s == 'csv' %>
       <a class="btn btn-default buttons-csv buttons-html5" tabindex="0" aria-controls="<%= table_id %>" href="#" data-action="click->datatable#exportCsv"><span><%= l10n('datatables.csv') %></span></a>

--- a/app/views/datatables/_column_filter.html.erb
+++ b/app/views/datatables/_column_filter.html.erb
@@ -1,0 +1,8 @@
+<%# Per-column select filter rendered inside a th, after the label.
+    data-column-default tells the Stimulus controller which value means "no
+    filter" so it omits the param; on change the controller appends
+    columns[<name>]=<value> to the redraw. no-selectric keeps it a native select
+    (freebies.selectric skips that class) so the change binding works and the
+    control renders unwrapped. The interaction-* decoration classes are applied
+    client-side and are not rendered here. %>
+<br><div class="input select optional datatable_filter_<%= col[:name] %>"><select value="<%= selected_value %>" title="<%= col[:label] %>" autocomplete="off" data-column-name="<%= col[:name] %>" data-column-index="<%= column_index %>" data-column-default="<%= col[:filter][:selected] %>" class="select optional no-selectric" id="datatable_filter_<%= col[:name] %>"><% col[:filter][:collection].each do |option| %><option value="<%= option %>"<%= ' selected="selected"'.html_safe if option.to_s == selected_value %>><%= option %></option><% end %></select></div>

--- a/app/views/datatables/_datatable.html.erb
+++ b/app/views/datatables/_datatable.html.erb
@@ -1,6 +1,6 @@
 <%# Datatable entry point: Stimulus controller scope + filter tab bar + the redraw wrapper. The _table partial inside #effective_datatable_wrapper is what Stimulus redraws replace; the tab bar outside it keeps its JS-managed state across redraws. %>
 <div class="container"
-     data-controller="datatable"
+     data-controller="datatable<%= ' bulk-actions' if table.bulk_actions.present? %>"
      data-datatable-url-value="<%= url %>"
      data-datatable-page-value="<%= pagy.page %>"
      data-datatable-per-value="<%= pagy.limit %>"
@@ -8,11 +8,12 @@
      data-datatable-order-value="<%= order %>"
      data-datatable-dir-value="<%= dir %>"
      data-datatable-date-from-value="<%= date_from %>"
-     data-datatable-date-to-value="<%= date_to %>">
+     data-datatable-date-to-value="<%= date_to %>"
+     data-datatable-disable-selectric-value="<%= table.disable_selectric? %>">
   <%= render partial: 'datatables/filter_tabs', locals: { filters: table.filters } if table.filters %>
   <%= render partial: 'datatables/date_filter', locals: { filter_name: table.date_filter } if table.date_filter %>
   <div id="effective_datatable_wrapper" data-datatable-target="wrapper">
     <%= render partial: 'datatables/table',
-               locals: { table: table, pagy: pagy, records: records, url: url, search: search, order: order, dir: dir } %>
+               locals: { table: table, pagy: pagy, records: records, url: url, search: search, order: order, dir: dir, column_filters: column_filters } %>
   </div>
 </div>

--- a/app/views/datatables/_table.html.erb
+++ b/app/views/datatables/_table.html.erb
@@ -1,5 +1,6 @@
 <%# The redraw region inside #effective_datatable_wrapper: table, buttons, search, length menu, info line, pager. The markup (grid layout, classes, ids, aria attributes) matches the existing DataTables DOM so the page renders identically. The two inline display styles are element state, kept inline. %>
 <% table_id = "#{table.param_key}-table" %>
+<% column_filters = local_assigns.fetch(:column_filters, {}) %>
 <div class="row">
   <div id="<%= table_id %>_wrapper" class="dataTables_wrapper form-inline dt-bootstrap no-footer">
     <div class="row">
@@ -22,21 +23,23 @@
             <tr>
               <% table.columns.each_with_index do |col, index| %>
                 <% label_text = %(span class="filter-label"#{col[:label]}/span) %>
+                <% legacy_index = index + table.column_index_offset %>
+                <% header_extra = capture do %><% if col[:filter] %><%= render partial: 'datatables/column_filter', locals: { col: col, column_index: legacy_index, selected_value: (column_filters[col[:name]].presence || col[:filter][:selected].to_s) } %><% elsif col[:header] == :bulk_all %><%= render partial: 'datatables/bulk_actions_header', locals: { col: col, column_index: legacy_index } %><% end %><% end %>
                 <% if col[:sortable] %>
                   <% sorted = col[:name] == order %>
                   <th class="col-<%= col[:type] %> col-<%= col[:name] %> sorting<%= " sorting_#{dir}" if sorted %>"
                       tabindex="0" aria-controls="<%= table_id %>" rowspan="1" colspan="1"
-                      data-column-index="<%= index %>"
+                      data-column-index="<%= legacy_index %>"
                       <% if sorted %>aria-sort="<%= dir == 'desc' ? 'descending' : 'ascending' %>"<% end %>
                       aria-label="<%= label_text %>: activate to sort column <%= sorted && dir == 'asc' ? 'descending' : 'ascending' %>"
                       data-action="click->datatable#sortClicked" data-column="<%= col[:name] %>"
-                      <% if col[:width] %>style="width: <%= col[:width] %>;"<% end %>><span class="filter-label"><%= col[:label] %></span></th>
+                      <% if col[:width] %>style="width: <%= col[:width] %>;"<% end %>><span class="filter-label"><%= col[:label] %></span><%= header_extra %></th>
                 <% else %>
                   <%# ordered: the collection arrives pre-sorted ascending by this column; render the asc indicator on its non-clickable header. %>
                   <th class="col-<%= col[:type] %> col-<%= col[:name] %> sorting_disabled<%= ' sorting_asc' if col[:ordered] %>"
-                      rowspan="1" colspan="1" data-column-index="<%= index %>"
+                      rowspan="1" colspan="1" data-column-index="<%= legacy_index %>"
                       aria-label="<%= label_text %>"
-                      <% if col[:width] %>style="width: <%= col[:width] %>;"<% end %>><span class="filter-label"><%= col[:label] %></span></th>
+                      <% if col[:width] %>style="width: <%= col[:width] %>;"<% end %>><span class="filter-label"><%= col[:label] %></span><%= header_extra %></th>
                 <% end %>
               <% end %>
             </tr>

--- a/app/views/exchanges/hbx_profiles/_invoice.html.slim
+++ b/app/views/exchanges/hbx_profiles/_invoice.html.slim
@@ -1,7 +1,11 @@
-h1.heading-text Employers
+- if EnrollRegistry.feature_enabled?(:refactored_datatables)
+  h1.heading-text Employers
+  = render partial: 'datatables/datatable', locals: @employers_datatable_locals
+- else
+  h1.heading-text Employers
 
-= render_datatable(@datatable)
+  = render_datatable(@datatable)
 
-javascript:
-  initializeDataTables()
-  disableSelectric = true
+  javascript:
+    initializeDataTables()
+    disableSelectric = true

--- a/app/views/exchanges/hbx_profiles/datatables/_employers_row.html.erb
+++ b/app/views/exchanges/hbx_profiles/datatables/_employers_row.html.erb
@@ -1,0 +1,54 @@
+<%# One Employers table row. employer_profile is resolved once and reused by the
+    later columns and the action dropdown. No td carries sorting_1: the default
+    order is the hidden created_at column, so no visible column is the active
+    sort. Each row-action link type ('ajax', 'post_ajax', 'disabled', 'hide') is
+    consumed by datatables/shared/_dropdown; 'hide' renders an empty entry. %>
+<%
+  employer_profile = row.organization.employer_profile
+  benefit_application = row.dt_display_benefit_application
+  row_actions_id = "employer_actions_#{employer_profile.id}"
+
+  dropdown = [
+    ['Transmit XML', '#', 'disabled'],
+    ['Generate Invoice', generate_invoice_exchanges_hbx_profiles_path(ids: [row.id]), table.generate_invoice_link_type(employer_profile)],
+    ['Create Plan Year', new_benefit_application_exchanges_hbx_profiles_path(benefit_sponsorship_id: row.id, employer_actions_id: row_actions_id), pundit_allow(HbxProfile, :can_create_benefit_application?) ? 'ajax' : 'hide'],
+    ['Change FEIN', edit_fein_exchanges_hbx_profiles_path(id: row.id, employer_actions_id: row_actions_id), pundit_allow(HbxProfile, :can_change_fein?) ? 'ajax' : 'hide'],
+    ['Force Publish', edit_force_publish_exchanges_hbx_profiles_path(id: employer_profile.latest_benefit_sponsorship.id, employer_actions_id: row_actions_id), table.force_publish_link_type(row, pundit_allow(HbxProfile, :can_force_publish?))]
+  ]
+
+  if pundit_allow(HbxProfile, :can_modify_plan_year?)
+    dropdown.insert(2, ['Plan Years', exchanges_employer_applications_path(employer_id: row, employers_action_id: row_actions_id), 'ajax'])
+  end
+
+  if individual_market_is_enabled?
+    people_id = Person.where("employer_staff_roles.employer_profile_id" => employer_profile._id).map(&:id)
+    dropdown.insert(2, ['View Username and Email', get_user_info_exchanges_hbx_profiles_path(people_id: people_id, employers_action_id: row_actions_id), !people_id.empty? && pundit_allow(Family, :can_view_username_and_email?) ? 'ajax' : 'disabled'])
+  end
+
+  if employer_attestation_is_enabled?
+    dropdown.insert(2, ['Attestation', edit_employers_employer_attestation_path(id: employer_profile.id, employer_actions_id: row_actions_id), 'ajax'])
+  end
+
+  if row.oe_extendable_benefit_applications.present? && pundit_allow(HbxProfile, :can_extend_open_enrollment?)
+    dropdown.insert(3, ['Extend Open Enrollment', oe_extendable_applications_exchanges_hbx_profiles_path(id: employer_profile.latest_benefit_sponsorship.id, employer_actions_id: row_actions_id), 'ajax'])
+  end
+
+  if row.oe_extended_applications.present? && pundit_allow(HbxProfile, :can_extend_open_enrollment?)
+    dropdown.insert(4, ['Close Open Enrollment', oe_extended_applications_exchanges_hbx_profiles_path(id: employer_profile.latest_benefit_sponsorship.id, employer_actions_id: row_actions_id), 'ajax'])
+  end
+%>
+<tr class="<%= row_class %>">
+  <td class="col-bulk_actions_column col-bulk_actions"><%= render partial: 'datatables/employers/bulk_actions_column', locals: { resource: row, resource_method: :id } %></td>
+  <td class="col-string col-legal_name"><%= link_to row.organization.legal_name.titleize, benefit_sponsors.profiles_employers_employer_profile_path(employer_profile.id, tab: 'home') %></td>
+  <td class="col-string col-fein"><%= row.organization.fein %></td>
+  <td class="col-integer col-hbx_id"><%= row.organization.hbx_id %></td>
+  <td class="col-string col-broker"><%= employer_profile.try(:active_broker_agency_legal_name).try(:titleize) %></td>
+  <td class="col-string col-source_kind"><%= row.source_kind.to_s.humanize %></td>
+  <td class="col-string col-plan_year_state"><%= benefit_application_summarized_state(benefit_application) if benefit_application.present? %></td>
+  <td class="col-string col-effective_date"><%= benefit_application.effective_period.min&.strftime("%m/%d/%Y") if benefit_application.present? %></td>
+  <td class="col-string col-invoiced?"><%= boolean_to_glyph(employer_profile.current_month_invoice.present?) %></td>
+  <% if employer_attestation_is_enabled? %>
+    <td class="col-string col-attestation_status"><%= employer_profile.attestation_status %></td>
+  <% end %>
+  <td class="col-string col-actions"><%= render partial: 'datatables/shared/dropdown', locals: { dropdowns: dropdown, row_actions_id: row_actions_id } %></td>
+</tr>

--- a/config/locales/view.en.yml
+++ b/config/locales/view.en.yml
@@ -5,6 +5,7 @@ en:
     csv: "CSV"
     excel: "Excel"
     print: "Print"
+    bulk_actions: "Bulk Actions"
     search_label: "Search:"
     per_page: "per page"
     showing_entries: "Showing %{from} to %{to} of %{count} entries"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,7 @@ Rails.application.routes.draw do
         post :employer_poc_datatable
         get :employer_invoice
         get :employer_datatable
+        get :employers_datatable
         post :employer_invoice_datatable
         post :generate_invoice
         get :edit_force_publish

--- a/spec/controllers/exchanges/hbx_profiles_controller_spec.rb
+++ b/spec/controllers/exchanges/hbx_profiles_controller_spec.rb
@@ -399,6 +399,138 @@ RSpec.describe Exchanges::HbxProfilesController, dbclean: :after_each do
       end
     end
   end
+
+  describe "Action # employers_datatable (:refactored_datatables)", dbclean: :after_each do
+    let(:person) { double("person", hbx_staff_role: double("hbx_staff_role")) }
+    let(:user) { double("user", :has_hbx_staff_role? => true, :person => person, :last_portal_visited => nil) }
+
+    before :each do
+      allow(user).to receive(:has_role?).with(:hbx_staff).and_return(true)
+      allow(EnrollRegistry).to receive(:feature_enabled?).and_call_original
+      allow(EnrollRegistry).to receive(:feature_enabled?).with(:refactored_datatables).and_return(true)
+      sign_in(user)
+    end
+
+    context "when the :refactored_datatables flag is disabled" do
+      before do
+        allow(EnrollRegistry).to receive(:feature_enabled?).with(:refactored_datatables).and_return(false)
+      end
+
+      it "404s the fragment endpoint" do
+        expect { get :employers_datatable, format: :html }.to raise_error(ActionController::RoutingError)
+      end
+
+      it "builds the legacy datatable on employer_datatable" do
+        get :employer_datatable, format: :js
+        expect(assigns(:datatable)).to be_a(Effective::Datatables::BenefitSponsorsEmployerDatatable)
+        expect(assigns(:employers_datatable_locals)).to be_nil
+      end
+    end
+
+    context "when the user is not an HBX staff member" do
+      let(:user) { double("user", :has_hbx_staff_role? => false, :person => person, :last_portal_visited => nil) }
+
+      it "denies access" do
+        get :employers_datatable, format: :html
+        expect(response).not_to have_http_status(:success)
+      end
+    end
+
+    context "when authorized with the flag enabled" do
+      it "renders the table fragment without a layout" do
+        get :employers_datatable, format: :html
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template("datatables/_table")
+      end
+
+      it "prepares the datatable locals on employer_datatable and employer_invoice" do
+        get :employer_datatable, format: :js
+        expect(assigns(:employers_datatable_locals)).to include(:table, :pagy, :records, :url, :column_filters)
+        expect(assigns(:datatable)).to be_nil
+
+        get :employer_invoice, xhr: true
+        expect(assigns(:employers_datatable_locals)).to include(:table, :pagy, :records, :url)
+      end
+
+      # The action streams via response_body=Enumerator, so the test response
+      # body must be materialized before parsing.
+      def streamed_csv_rows
+        body = response.body
+        CSV.parse(body.is_a?(String) ? body : body.to_a.join)
+      end
+
+      it "streams a CSV with the excluded-actions/bulk-actions header row" do
+        get :employers_datatable, params: { employers: "all" }, format: :csv
+        expect(response.headers["Content-Type"]).to eq("text/csv; charset=utf-8")
+        expect(response.headers["Content-Disposition"]).to include('filename="employers.csv"')
+        expect(streamed_csv_rows.first).to start_with("Legal Name", "FEIN", "HBX ID", "Broker", "Source Kind")
+      end
+
+      it "routes the source_kind column filter param through to the table search_column hook" do
+        expect_any_instance_of(Datatables::EmployersTable).to receive(:search_column).with(anything, "source_kind", "conversion").and_call_original
+        get :employers_datatable, params: { columns: { source_kind: "conversion" } }, format: :csv
+      end
+
+      context "with real employer data" do
+        let(:site) { FactoryBot.create(:benefit_sponsors_site, :with_benefit_market, :as_hbx_profile, :cca) }
+        let!(:self_serve_org) do
+          FactoryBot.create(:benefit_sponsors_organizations_general_organization, :with_aca_shop_cca_employer_profile,
+                            site: site, legal_name: "Self Serve Co").tap do |org|
+            org.employer_profile.add_benefit_sponsorship.tap { |bs| bs.update(source_kind: :self_serve) }
+          end
+        end
+        let!(:conversion_org) do
+          FactoryBot.create(:benefit_sponsors_organizations_general_organization, :with_aca_shop_cca_employer_profile,
+                            site: site, legal_name: "Conversion Co").tap do |org|
+            org.employer_profile.add_benefit_sponsorship.tap { |bs| bs.update(source_kind: :conversion) }
+          end
+        end
+
+        it "streams every employer when no column filter is active" do
+          get :employers_datatable, params: { employers: "all" }, format: :csv
+          legal_names = streamed_csv_rows.drop(1).map(&:first)
+          expect(legal_names).to include("Self Serve Co", "Conversion Co")
+        end
+
+        it "restricts the CSV to the selected source_kind" do
+          get :employers_datatable, params: { employers: "all", columns: { source_kind: "conversion" } }, format: :csv
+          legal_names = streamed_csv_rows.drop(1).map(&:first)
+          expect(legal_names).to include("Conversion Co")
+          expect(legal_names).not_to include("Self Serve Co")
+        end
+      end
+    end
+  end
+
+  describe "Action # bulk actions (Generate Invoice / Mark Binder Paid round-trip)", dbclean: :after_each do
+    let(:site) { FactoryBot.create(:benefit_sponsors_site, :with_benefit_market, :as_hbx_profile, :cca) }
+    let(:employer_organization) do
+      FactoryBot.create(:benefit_sponsors_organizations_general_organization, :with_aca_shop_cca_employer_profile, site: site).tap do |org|
+        org.employer_profile.add_benefit_sponsorship.save
+      end
+    end
+    let(:benefit_sponsorship) { employer_organization.benefit_sponsorships.first }
+    let(:person) do
+      FactoryBot.create(:person, :with_hbx_staff_role).tap do |staff|
+        FactoryBot.create(:permission, :super_admin).tap { |permission| staff.hbx_staff_role.update_attributes(permission_id: permission.id) }
+      end
+    end
+    let(:user) { FactoryBot.create(:user, person: person) }
+
+    before { sign_in(user) }
+
+    it "marks the selected employers binder paid and returns the surfaced JSON message" do
+      allow(BenefitSponsors::BenefitSponsorships::AcaShopBenefitSponsorshipService).to receive(:set_binder_paid).with([benefit_sponsorship.id.to_s])
+      post :binder_paid, params: { ids: [benefit_sponsorship.id.to_s] }, format: :json
+      expect(response).to have_http_status(:success)
+      expect(JSON.parse(response.body)["message"]).to include("binder paid")
+    end
+
+    it "submits the selected employers for invoice generation" do
+      get :generate_invoice, params: { ids: [benefit_sponsorship.id.to_s] }, format: :js
+      expect(response).to have_http_status(:success)
+    end
+  end
 =begin
   describe "#create" do
     let(:user) { double("User")}

--- a/spec/models/datatables/employers_table_spec.rb
+++ b/spec/models/datatables/employers_table_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Datatables::EmployersTable, dbclean: :after_each do
+  subject(:table) { described_class.new }
+
+  describe '#columns' do
+    context 'when employer attestations are enabled' do
+      before { allow(table).to receive(:employer_attestation_is_enabled?).and_return(true) }
+
+      it 'mirrors the legacy column order and labels, including the attestation column' do
+        expect(table.columns.map { |col| col[:name] }).to eq(
+          %w[bulk_actions legal_name fein hbx_id broker source_kind plan_year_state effective_date invoiced? attestation_status actions]
+        )
+        expect(table.columns.map { |col| col[:label] }).to eq(
+          ['', 'Legal Name', 'FEIN', 'HBX ID', 'Broker', 'Source Kind', 'Plan Year State', 'Effective Date', 'Invoiced?', 'Attestation Status', 'Actions']
+        )
+      end
+    end
+
+    context 'when employer attestations are disabled' do
+      before { allow(table).to receive(:employer_attestation_is_enabled?).and_return(false) }
+
+      it 'drops the attestation_status column' do
+        expect(table.columns.map { |col| col[:name] }).not_to include('attestation_status')
+      end
+    end
+
+    it 'marks only effective_date sortable, matching the legacy flags' do
+      expect(table.columns.select { |col| col[:sortable] }.map { |col| col[:name] }).to eq(%w[effective_date])
+    end
+
+    it 'declares the source_kind select filter (the app\'s only per-column filter)' do
+      source_kind = table.columns.find { |col| col[:name] == 'source_kind' }
+      expect(source_kind[:filter][:selected]).to eq('all')
+      expect(source_kind[:filter][:collection]).to eq([:all] + BenefitSponsors::BenefitSponsorships::BenefitSponsorship::SOURCE_KINDS)
+    end
+
+    it 'flags the bulk_actions column header so the check-all box renders' do
+      expect(table.columns.first).to include(name: 'bulk_actions', type: :bulk_actions_column, header: :bulk_all)
+    end
+  end
+
+  describe '#default_order_column' do
+    it 'orders by the hidden created_at column, so no visible header is the active sort' do
+      expect(table.default_order_column).to eq('created_at')
+    end
+  end
+
+  describe '#column_index_offset' do
+    it 'offsets by one for the hidden leading created_at column' do
+      expect(table.column_index_offset).to eq(1)
+    end
+  end
+
+  describe '#collection' do
+    it 'narrows BenefitSponsorship by the active employers tab scope through the whitelist' do
+      criteria = table.collection(employers: 'benefit_sponsorship_applicant')
+      expect(criteria.selector['aasm_state']).to eq(:applicant)
+    end
+
+    it 'ignores a filter value that is not on the whitelist (injection guard)' do
+      criteria = table.collection(employers: 'destroy_all')
+      expect(criteria.selector).to eq(BenefitSponsors::BenefitSponsorships::BenefitSponsorship.unscoped.selector)
+    end
+
+    it 'returns the unscoped collection for the All tab' do
+      criteria = table.collection(employers: 'all')
+      expect(criteria.selector).to eq(BenefitSponsors::BenefitSponsorships::BenefitSponsorship.unscoped.selector)
+    end
+  end
+
+  describe '#search_column' do
+    let(:collection) { double('collection') }
+
+    it 'applies the source_kind filter for a concrete value' do
+      expect(collection).to receive(:datatable_search_for_source_kind).with(:conversion).and_return(:filtered)
+      expect(table.search_column(collection, 'source_kind', 'conversion')).to eq(:filtered)
+    end
+
+    it 'is a no-op for the "all" value' do
+      expect(collection).not_to receive(:datatable_search_for_source_kind)
+      expect(table.search_column(collection, 'source_kind', 'all')).to eq(collection)
+    end
+
+    it 'is a no-op for any other column' do
+      expect(table.search_column(collection, 'legal_name', 'conversion')).to eq(collection)
+    end
+  end
+
+  describe '#bulk_actions' do
+    it 'declares Generate Invoice and Mark Binder Paid against their existing endpoints' do
+      labels = table.bulk_actions.map { |action| action[:label] }
+      expect(labels).to eq(['Generate Invoice', 'Mark Binder Paid'])
+      expect(table.bulk_actions.first[:url]).to eq('/exchanges/hbx_profiles/generate_invoice')
+      expect(table.bulk_actions.last[:url]).to eq('/exchanges/hbx_profiles/binder_paid')
+    end
+  end
+
+  describe 'csv export' do
+    before { allow(table).to receive(:employer_attestation_is_enabled?).and_return(false) }
+
+    it 'excludes the bulk-actions and actions columns from the headers' do
+      expect(table.csv_headers).to eq(
+        ['Legal Name', 'FEIN', 'HBX ID', 'Broker', 'Source Kind', 'Plan Year State', 'Effective Date', 'Invoiced?']
+      )
+    end
+
+    it 'renders plain-text cell values for one row' do
+      organization = double('organization', legal_name: 'Acme Co', fein: '223456789', hbx_id: '12345')
+      employer_profile = double('employer_profile', active_broker_agency_legal_name: 'Best Brokers', current_month_invoice: nil)
+      benefit_application = double('benefit_application', effective_period: (Date.new(2026, 1, 1)..Date.new(2026, 12, 31)))
+      row = double('benefit_sponsorship', organization: organization, source_kind: :self_serve, dt_display_benefit_application: benefit_application)
+      allow(organization).to receive(:employer_profile).and_return(employer_profile)
+      allow(table).to receive(:helpers).and_return(double(benefit_application_summarized_state: 'Enrolling'))
+
+      expect(table.csv_row(row)).to eq(
+        ['Acme Co', '223456789', '12345', 'Best Brokers', 'Self serve', 'Enrolling', '01/01/2026', false]
+      )
+    end
+  end
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/health-connector/enroll/blob/master/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Inert code (no impact until run, e.g. data fix or migration, manually triggered bulk process, etc.)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)
- [ ] Release (Prepares code for a release, e.g., version bumps, changelog updates, tagging, deployment scripts)

# What is the ticket # detailing the issue?

Ticket: https://app.clickup.com/t/9011313074/868jab71m

> **Stacked PR.** Base branch is `datatables_refactor_phase3_outstanding_verifications`, not `master`. The stack merges bottom-up: #3200 (Phase 1) → #3203 (Phase 2) → #3208 (Phase 3) → this (Phase 4). Review this PR's diff against the Phase 3 branch.

# A brief description of the changes

Phase 4 of the Effective Datatables → Pagy + Mongoid + Stimulus refactor: ports the **Employers** and **Employer Invoice** admin tabs (both back onto `Effective::Datatables::BenefitSponsorsEmployerDatatable` + the shared `_invoice.html.slim`) to the new stack behind the existing `:refactored_datatables` flag. This is the heaviest table in the app and adds the last two scaffold capabilities — **bulk actions** and a **per-column select filter** — making the scaffold feature-complete.

**Current behavior:** with the flag off, the Employers / Employer Invoice tabs render the vendored jQuery DataTables stack (unchanged by this PR).

**New behavior:** with the flag on, both tabs render via `Datatables::EmployersTable` + the shared Pagy/Stimulus partials, pixel-identical to the legacy DOM, plus:
- **Bulk actions** — a new `bulk-actions` Stimulus controller drives the check-all / per-row checkboxes (eligibility via `data-status`, ineligible rows disabled), enables/disables the dropdown, and POSTs the selected ids to the existing `generate_invoice` / `binder_paid` endpoints (axios + CSRF), surfacing the result in the processing panel.
- **Per-column `source_kind` select filter** — the app's only column filter; the th renders a native select, the controller appends `columns[source_kind]=<value>` to the redraw, and the PORO's `search_column` hook maps it to `datatable_search_for_source_kind`.
- A new flag-gated `employers_datatable` fragment/CSV endpoint (Pundit-authorized, 404 when the flag is off). CSV streams the full filtered set, respecting the active filter tab **and** the column filter.

The `FILTER_MAPPINGS` / `call_safe_method` whitelist is transcribed verbatim (a deliberate injection guard). Legacy quirks (created_at default order, deep-filter no-ops, `data-column-index` offset) are reproduced for parity, not "fixed".

# Feature Flag

Variable name: `REFACTORED_DATATABLES_IS_ENABLED` — applies to all clients; this PR exercises it on **CCA**. Default off. The flag was added in Phase 1; no new flag here.

# Additional Context

**Verification (this change only):**
- RuboCop clean on branch files (`rubocop-git datatables_refactor_phase3_outstanding_verifications`).
- RSpec: `spec/models/datatables/employers_table_spec.rb` + the `employers_datatable` / bulk-action blocks in `spec/controllers/exchanges/hbx_profiles_controller_spec.rb` — 123 examples, 0 failures (PORO contract, authz denial, flag-off 404, HTML fragment, streamed CSV respecting filters + the `source_kind` column filter, bulk-action round-trip).
- Cucumber both flag states: `features/admin/user_account.feature` green in both; `features/hbx_admin/create_plan_year.feature` behaves identically in both (the 3 remaining failures are a pre-existing `.plan-year` assertion issue present in the legacy stack too, not introduced here).
- DOM snapshot parity: flag-OFF vs flag-ON structural diff ~99.75% (only ignored load-time decorations + the deliberately-dropped legacy inline `<script>`/`<style>` differ).
- Manual (Chrome DevTools, flag ON): full filter-hierarchy walk; attestation tab + Attestation Status column present (CCA); bulk Generate Invoice + Mark Binder Paid (single POST 200, single confirm, ineligible disabling); `source_kind` filter; CSV carries active filters; User Accounts / Broker Agencies / Employers all render flag-ON with zero console errors.

No Gemfile change (Pagy added in Phase 1); no image rebuild needed.
