### PR TITLE
Removed Health only validation in the bqt calculation to account for Health & Dental

### DIFF
--- a/components/sponsored_benefits/app/models/sponsored_benefits/services/plan_cost_service.rb
+++ b/components/sponsored_benefits/app/models/sponsored_benefits/services/plan_cost_service.rb
@@ -252,7 +252,7 @@ class SponsoredBenefits::Services::PlanCostService
     if age_of(member) > 20
       1.00
     else
-      if child_index(member, census_employee) > 2 && @plan.health?
+      if child_index(member, census_employee) > 2
         0.00
       else
         1.00

--- a/components/sponsored_benefits/app/models/sponsored_benefits/services/plan_cost_service.rb
+++ b/components/sponsored_benefits/app/models/sponsored_benefits/services/plan_cost_service.rb
@@ -251,12 +251,10 @@ class SponsoredBenefits::Services::PlanCostService
   def large_family_factor(member, census_employee)
     if age_of(member) > 20
       1.00
+    elsif child_index(member, census_employee) > 2
+      0.00
     else
-      if child_index(member, census_employee) > 2
-        0.00
-      else
-        1.00
-      end
+      1.00
     end
   end
 

--- a/components/sponsored_benefits/spec/models/sponsored_benefits/services/plan_cost_service_spec.rb
+++ b/components/sponsored_benefits/spec/models/sponsored_benefits/services/plan_cost_service_spec.rb
@@ -122,4 +122,95 @@ RSpec.describe SponsoredBenefits::Services::PlanCostService, type: :model, dbcle
       expect(@pcs.reference_plan.dental?).to be_truthy
     end
   end
+
+  context "3-child premium cap for dental plans" do
+    let(:start_on) { benefit_sponsorship_enrollment_period.min }
+    let(:dental_plan) do
+      FactoryBot.create(:plan, :with_dental_coverage, :with_complex_premium_tables, :with_rating_factors)
+    end
+    let(:dental_benefit_group) do
+      benefit_application.benefit_groups.first.tap do |bg|
+        bg.dental_reference_plan_id = dental_plan.id
+        bg.build_dental_relationship_benefits
+        bg.dental_relationship_benefits.each do |rb|
+          rb.premium_pct = case rb.relationship
+                           when 'employee'       then 80.0
+                           when 'child_under_26' then 75.0
+                           else 0.0
+                           end
+        end
+      end
+    end
+    let!(:employee_with_four_children) do
+      FactoryBot.create(
+        :plan_design_census_employee,
+        benefit_sponsorship_id: benefit_sponsorship.id,
+        dob: start_on - 43.years
+      ).tap do |ce|
+        [20, 18, 16, 14].each do |age|
+          ce.census_dependents.create!(
+            employee_relationship: 'child_under_26',
+            dob: start_on - age.years,
+            first_name: 'Kid',
+            last_name: 'Test',
+            gender: 'female'
+          )
+        end
+      end
+    end
+    let(:service) do
+      SponsoredBenefits::Services::PlanCostService.new(benefit_group: dental_benefit_group).tap do |s|
+        s.plan = dental_plan
+      end
+    end
+
+    before do
+      Rails.cache.clear
+      employee_with_four_children.reload
+      allow(service).to receive(:active_census_employees).and_return([employee_with_four_children])
+      allow(Caches::PlanDetails).to receive(:lookup_rate_with_area).and_return(20.0)
+    end
+
+    describe "#large_family_factor with a dental plan" do
+      let(:children_oldest_first) do
+        employee_with_four_children.reload.census_dependents
+                                  .sort_by { |c| -c.age_on(start_on) }
+      end
+
+      it "returns 1.00 for the 1st oldest child under 21" do
+        expect(service.large_family_factor(children_oldest_first[0], employee_with_four_children)).to eq 1.00
+      end
+
+      it "returns 1.00 for the 2nd oldest child under 21" do
+        expect(service.large_family_factor(children_oldest_first[1], employee_with_four_children)).to eq 1.00
+      end
+
+      it "returns 1.00 for the 3rd oldest child under 21" do
+        expect(service.large_family_factor(children_oldest_first[2], employee_with_four_children)).to eq 1.00
+      end
+
+      it "returns 0.00 for the 4th child under 21 - 3-child cap applies to dental same as health" do
+        expect(service.large_family_factor(children_oldest_first[3], employee_with_four_children)).to eq 0.00
+      end
+    end
+
+    describe "#monthly_employer_contribution_amount" do
+      # With mocked rate 20.0 and 80% employee / 75% child_under_26 contribution:
+      #   employee (age 43): min(1.00 x 20.0 x 80%, 20.0) x 1.00 = 16.00
+      #   child age 20 (idx 0): min(1.00 x 20.0 x 75%, 20.0) x 1.00 = 15.00
+      #   child age 18 (idx 1): 15.00
+      #   child age 16 (idx 2): 15.00
+      #   child age 14 (idx 3): min(0.00, 0.00) x 0.00 = 0.00  (3-child cap)
+      #   -----------------------------------------------
+      #   Correct total: 61.00
+      #   Buggy total:   76.00 (all 4 children charged)
+      it "charges the employer for only the 3 oldest children, excluding the 4th" do
+        expect(service.monthly_employer_contribution_amount).to eq BigDecimal("61.0")
+      end
+
+      it "does not produce the inflated total that includes the 4th child's premium" do
+        expect(service.monthly_employer_contribution_amount).not_to eq BigDecimal("76.0")
+      end
+    end
+  end
 end

--- a/components/sponsored_benefits/spec/models/sponsored_benefits/services/plan_cost_service_spec.rb
+++ b/components/sponsored_benefits/spec/models/sponsored_benefits/services/plan_cost_service_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe SponsoredBenefits::Services::PlanCostService, type: :model, dbcle
     describe "#large_family_factor with a dental plan" do
       let(:children_oldest_first) do
         employee_with_four_children.reload.census_dependents
-                                  .sort_by { |c| -c.age_on(start_on) }
+                                   .sort_by { |c| -c.age_on(start_on) }
       end
 
       it "returns 1.00 for the 1st oldest child under 21" do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/health-connector/enroll/blob/master/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Inert code (no impact until run, e.g. data fix or migration, manually triggered bulk process, etc.)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)
- [ ] Release (Prepares code for a release, e.g., version bumps, changelog updates, tagging, deployment scripts)

# What is the ticket # detailing the issue?

Ticket: https://app.clickup.com/t/9011313074/868hueg63

# A brief description of the changes

Current behavior: Broker BQT tool has incorrect values for a Dental enrollment for a employee that has 3+ under 21 children dependents, not matching the plan shopping amounts

New behavior: Broker BQT tool has correct values for a Dental enrollment for a employee that has 3+ under 21 children dependents, matching the plan shopping amounts

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:


# Additional Context
Include any additional context that may be relevant to the peer review process.
