### PR TITLE
CCAOM-261: Create broker inbox message when notice is generated

### DIFF
--- a/components/notifier/app/models/notifier/notice_builder.rb
+++ b/components/notifier/app/models/notifier/notice_builder.rb
@@ -202,9 +202,11 @@ module Notifier
 
     def send_generic_notice_alert_to_broker
       return unless resource.is_a?(BenefitSponsors::Organizations::AcaShopCcaEmployerProfile)
+
       primary_broker_role = resource.broker_agency_profile&.primary_broker_role
       broker_person = primary_broker_role&.person
       return if broker_person.blank?
+
       UserMailer.generic_notice_alert_to_ba(broker_person.full_name, primary_broker_role.email_address, resource.legal_name.titleize).deliver_now
       create_broker_inbox_message(broker_person)
     end

--- a/components/notifier/app/models/notifier/notice_builder.rb
+++ b/components/notifier/app/models/notifier/notice_builder.rb
@@ -201,11 +201,28 @@ module Notifier
     end
 
     def send_generic_notice_alert_to_broker
-      if resource.is_a?(BenefitSponsors::Organizations::AcaShopCcaEmployerProfile) && resource.broker_agency_profile.present?
-        broker_name = resource.broker_agency_profile.primary_broker_role.person.full_name
-        broker_email = resource.broker_agency_profile.primary_broker_role.email_address
-        UserMailer.generic_notice_alert_to_ba(broker_name, broker_email, resource.legal_name.titleize).deliver_now
+      return unless resource.is_a?(BenefitSponsors::Organizations::AcaShopCcaEmployerProfile)
+      primary_broker_role = resource.broker_agency_profile&.primary_broker_role
+      broker_person = primary_broker_role&.person
+      return if broker_person.blank?
+      UserMailer.generic_notice_alert_to_ba(broker_person.full_name, primary_broker_role.email_address, resource.legal_name.titleize).deliver_now
+      create_broker_inbox_message(broker_person)
+    end
+
+    def create_broker_inbox_message(broker_person)
+      if broker_person.inbox.blank?
+        broker_person.inbox = Inbox.new
+        broker_person.save!
       end
+      message_body = "A notice has been generated for your client, #{resource.legal_name.titleize}. Please log in to your account to view this message or navigate to their employer account to review the notice."
+      message = broker_person.inbox.messages.build(
+        subject: "New Notice: #{subject}",
+        body: message_body,
+        from: site_short_name
+      )
+      message.save!
+    rescue StandardError => e
+      Rails.logger.error("Failed to create broker inbox message for person #{broker_person.id}: #{e.message}")
     end
 
     def store_paper_notice

--- a/spec/models/notifier/notice_kind_spec.rb
+++ b/spec/models/notifier/notice_kind_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Notifier::NoticeKind, type: :model, dbclean: :after_each do
+  let(:site) do
+    FactoryBot.create(:benefit_sponsors_site, :with_benefit_market, :as_hbx_profile, :cca)
+  end
+
+  let(:employer_organization) do
+    FactoryBot.create(
+      :benefit_sponsors_organizations_general_organization,
+      :with_aca_shop_cca_employer_profile,
+      site: site
+    )
+  end
+
+  let(:employer_profile) { employer_organization.employer_profile }
+
+  let(:broker_organization) do
+    FactoryBot.create(
+      :benefit_sponsors_organizations_general_organization,
+      :with_broker_agency_profile,
+      site: site
+    )
+  end
+
+  let(:broker_agency_profile) { broker_organization.broker_agency_profile }
+
+  let(:broker_role) do
+    FactoryBot.create(
+      :broker_role,
+      aasm_state: 'active',
+      benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id
+    )
+  end
+
+  let(:broker_person) { broker_role.person }
+
+  let(:notice_kind) do
+    nk = Notifier::NoticeKind.new(title: 'Test Employer Notice', notice_number: 'SHOP001')
+    nk.resource = employer_profile
+    nk
+  end
+
+  before do
+    benefit_sponsorship = employer_profile.add_benefit_sponsorship
+    benefit_sponsorship.save!
+    broker_agency_profile.update_attributes!(primary_broker_role: broker_role)
+    broker_role.update_attributes!(broker_agency_profile_id: broker_agency_profile.id)
+    broker_agency_profile.approve!
+    employer_profile.hire_broker_agency(broker_agency_profile)
+    employer_profile.save!
+  end
+
+  describe '#send_generic_notice_alert_to_broker' do
+    context 'when the resource is an AcaShopCcaEmployerProfile with a broker' do
+      before { allow(UserMailer).to receive_message_chain(:generic_notice_alert_to_ba, :deliver_now) }
+
+      it 'sends the broker email notification' do
+        notice_kind.send_generic_notice_alert_to_broker
+
+        expect(UserMailer).to have_received(:generic_notice_alert_to_ba).with(
+          broker_person.full_name,
+          broker_role.email_address,
+          employer_organization.legal_name.titleize
+        )
+      end
+
+      it 'creates an inbox message for the broker' do
+        expect { notice_kind.send_generic_notice_alert_to_broker }
+          .to change { broker_person.reload.inbox.messages.count }.by(1)
+      end
+    end
+
+    context 'when the resource has no broker agency profile' do
+      before { allow(employer_profile).to receive(:broker_agency_profile).and_return(nil) }
+
+      it 'does not send email or create an inbox message' do
+        expect(UserMailer).not_to receive(:generic_notice_alert_to_ba)
+        expect { notice_kind.send_generic_notice_alert_to_broker }
+          .not_to change { broker_person.reload.inbox.messages.count }
+      end
+    end
+
+    context 'when the broker agency has no primary broker role' do
+      before { allow(broker_agency_profile).to receive(:primary_broker_role).and_return(nil) }
+
+      it 'does not send email or create an inbox message' do
+        expect(UserMailer).not_to receive(:generic_notice_alert_to_ba)
+        expect { notice_kind.send_generic_notice_alert_to_broker }
+          .not_to change { broker_person.reload.inbox.messages.count }
+      end
+    end
+
+    context 'when the resource is not an AcaShopCcaEmployerProfile' do
+      before { notice_kind.resource = double('other_resource') }
+
+      it 'does nothing' do
+        expect(UserMailer).not_to receive(:generic_notice_alert_to_ba)
+        notice_kind.send_generic_notice_alert_to_broker
+      end
+    end
+  end
+
+  describe '#create_broker_inbox_message' do
+    before { broker_person.save! }
+
+    it 'adds a message to the broker inbox' do
+      expect { notice_kind.send(:create_broker_inbox_message, broker_person) }
+        .to change { broker_person.reload.inbox.messages.count }.by(1)
+    end
+
+    it 'sets subject to "New Notice: <title>"' do
+      notice_kind.send(:create_broker_inbox_message, broker_person)
+      expect(broker_person.reload.inbox.messages.last.subject).to eq("New Notice: #{notice_kind.title}")
+    end
+
+    it 'includes the employer legal name in the body' do
+      notice_kind.send(:create_broker_inbox_message, broker_person)
+      expect(broker_person.reload.inbox.messages.last.body).to include(employer_organization.legal_name.titleize)
+    end
+
+    it 'sets from to the site short name' do
+      notice_kind.send(:create_broker_inbox_message, broker_person)
+      expect(broker_person.reload.inbox.messages.last.from).to eq(notice_kind.site_short_name)
+    end
+
+    context 'when the broker person has no inbox' do
+      before do
+        broker_person.save!
+        allow(broker_person).to receive(:inbox).and_return(nil, broker_person.reload.inbox)
+      end
+
+      it 'initializes a new inbox without injecting a welcome message' do
+        expect(broker_person).to receive(:inbox=).with(instance_of(Inbox)).and_call_original
+        expect(broker_person).not_to receive(:create_inbox)
+        notice_kind.send(:create_broker_inbox_message, broker_person)
+      end
+    end
+  end
+end

--- a/spec/models/notifier/notice_kind_spec.rb
+++ b/spec/models/notifier/notice_kind_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Notifier::NoticeKind, type: :model, dbclean: :after_each do
       it 'does not send email or create an inbox message' do
         expect(UserMailer).not_to receive(:generic_notice_alert_to_ba)
         expect { notice_kind.send_generic_notice_alert_to_broker }
-          .not_to change { broker_person.reload.inbox.messages.count }
+          .not_to(change { broker_person.reload.inbox.messages.count })
       end
     end
 
@@ -89,7 +89,7 @@ RSpec.describe Notifier::NoticeKind, type: :model, dbclean: :after_each do
       it 'does not send email or create an inbox message' do
         expect(UserMailer).not_to receive(:generic_notice_alert_to_ba)
         expect { notice_kind.send_generic_notice_alert_to_broker }
-          .not_to change { broker_person.reload.inbox.messages.count }
+          .not_to(change { broker_person.reload.inbox.messages.count })
       end
     end
 


### PR DESCRIPTION
## Summary

Fixes a bug (CCAOM-261) where brokers received email notifications for employer notices but saw 0 messages in their account inbox.

**Root cause:** `Notifier::NoticeBuilder#send_generic_notice_alert_to_broker` sent the `UserMailer` email alert but never created an inbox message on the broker's Person record.

**Changes:**
- Add `create_broker_inbox_message` to `Notifier::NoticeBuilder` — creates an inbox message on the broker's Person account when a notice is generated for their employer client
- Guard against nil `primary_broker_role` (broker agency can exist without a primary role assigned); previously all three `.primary_broker_role` calls were unguarded and would raise `NoMethodError`
- Build an empty `Inbox` directly (instead of calling `Person#create_inbox`) to avoid injecting an unrelated welcome message into an existing broker's mailbox
- Wrap message persistence in a rescue so a broker-side inbox failure cannot abort an otherwise-successful notice generation
- Add `spec/models/notifier/notice_kind_spec.rb` covering: happy path (email sent + inbox message created), nil broker agency, nil primary broker role, wrong resource type, and message field values

**ClickUp:** https://app.clickup.com/t/9011313074/868gv08pa

## Test plan

- [ ] Run `bundle exec rspec spec/models/notifier/notice_kind_spec.rb` — all examples pass
- [ ] Manually trigger a notice for an employer with a broker agency in staging/UAT and confirm broker inbox shows a new message
- [ ] Trigger a notice for an employer with a broker agency where `primary_broker_role` is nil — confirm notice completes without error