### PR TITLE
Per-carrier plan validation reports + drop HIOS ids without products

### DIFF
--- a/app/models/services/plan_validation_report.rb
+++ b/app/models/services/plan_validation_report.rb
@@ -86,34 +86,20 @@ module Services
 
     def sheet2
       worksheet2 = workbook.add_worksheet('Report2')
-      headers = %w[PlanYearId CarrierId CarrierName RatingArea Age(Range) IndividualRate]
+      headers = %w[PlanYearId CarrierId CarrierName RatingArea Age(Range) IndividualRate EffectiveDate ExpirationDate]
       generate_excel(headers, worksheet2)
       b = 1
       issuer_hios_ids.each do |issuer_hios_id|
         issuer_products = products(active_year).where(hios_id: /#{issuer_hios_id}/i)
         rating_area_ids(issuer_products).each do |rating_area_key, rating_area_value|
-          premium_tables = issuer_products.map(&:premium_tables).flatten.select do |prem_tab|
-            start_date = prem_tab.effective_period.min.to_date
-            end_date = prem_tab.effective_period.max.to_date
-            (start_date..end_date).cover?(active_date) && prem_tab.rating_area_id.to_s == rating_area_key
+          premium_tables_by_period = issuer_products.map(&:premium_tables).flatten.select do |prem_tab|
+            prem_tab.rating_area_id.to_s == rating_area_key
+          end.group_by do |prem_tab|
+            [prem_tab.effective_period.min.to_date, prem_tab.effective_period.max.to_date]
           end
-          (14..64).each do |value|
-            age = case value
-                  when 14
-                    "0-14"
-                  when 64
-                    "64 and over"
-                  else
-                    value
-                  end
-            age_cost = premium_tables.map(&:premium_tuples).flatten.select{|tuple| tuple.age == value}.map(&:cost).sum
-            carrier_name = issuer_products.first.issuer_profile.legal_name
-            ra_val = rating_area_value.gsub("R-MA00", "Rating Area ")
-            data = [active_year, issuer_hios_id, carrier_name, ra_val, age, age_cost.round(2).to_s]
-            generate_data(worksheet2, data, b)
-            b += 1
-          rescue StandardError
-            puts "Report2 Plan validation issue for issuer_hios_id: #{issuer_hios_id}" unless Rails.env.test?
+
+          premium_tables_by_period.sort_by { |period, _| period.first }.each do |(effective_start, effective_end), premium_tables|
+            b = write_sheet2_age_rows(worksheet2, premium_tables, issuer_hios_id, issuer_products, rating_area_value, effective_start, effective_end, b)
           end
         end
       end
@@ -288,6 +274,27 @@ module Services
         puts "Report9 plan validation issue for Product_id: #{product.id}" unless Rails.env.test?
       end
       puts "Successfully generated 9th Plan validation report for Super Group ID's" unless Rails.env.test?
+    end
+
+    private
+
+    def write_sheet2_age_rows(worksheet, premium_tables, issuer_hios_id, issuer_products, rating_area_value, effective_start, effective_end, row_index)
+      carrier_name = issuer_products.first.issuer_profile.legal_name
+      ra_val = rating_area_value.gsub("R-MA00", "Rating Area ")
+      (14..64).each do |value|
+        age = case value
+              when 14 then "0-14"
+              when 64 then "64 and over"
+              else value
+              end
+        age_cost = premium_tables.map(&:premium_tuples).flatten.select { |tuple| tuple.age == value }.map(&:cost).sum
+        data = [active_year, issuer_hios_id, carrier_name, ra_val, age, age_cost.round(2).to_s, effective_start.to_s, effective_end.to_s]
+        generate_data(worksheet, data, row_index)
+        row_index += 1
+      rescue StandardError
+        puts "Report2 Plan validation issue for issuer_hios_id: #{issuer_hios_id}" unless Rails.env.test?
+      end
+      row_index
     end
   end
 end

--- a/app/models/services/plan_validation_report.rb
+++ b/app/models/services/plan_validation_report.rb
@@ -98,14 +98,22 @@ module Services
       issuer_hios_ids.each do |issuer_hios_id|
         issuer_products = products(active_year).where(hios_id: /#{issuer_hios_id}/i)
         rating_area_ids(issuer_products).each do |rating_area_key, rating_area_value|
-          premium_tables_by_period = issuer_products.map(&:premium_tables).flatten.select do |prem_tab|
+          rating_area_tables = issuer_products.map(&:premium_tables).flatten.select do |prem_tab|
             prem_tab.rating_area_id.to_s == rating_area_key
-          end.group_by do |prem_tab|
+          end
+          premium_tables_by_period = rating_area_tables.group_by do |prem_tab|
             [prem_tab.effective_period.min.to_date, prem_tab.effective_period.max.to_date]
           end
 
           premium_tables_by_period.sort_by { |period, _| period.first }.each do |(effective_start, effective_end), premium_tables|
-            b = write_sheet2_age_rows(worksheet2, premium_tables, issuer_hios_id, issuer_products, rating_area_value, effective_start, effective_end, b)
+            row_context = {
+              issuer_hios_id: issuer_hios_id,
+              carrier_name: issuer_products.first.issuer_profile.legal_name,
+              rating_area_value: rating_area_value,
+              effective_start: effective_start,
+              effective_end: effective_end
+            }
+            b = write_sheet2_age_rows(worksheet2, premium_tables, row_context, b)
           end
         end
       end
@@ -284,9 +292,12 @@ module Services
 
     private
 
-    def write_sheet2_age_rows(worksheet, premium_tables, issuer_hios_id, issuer_products, rating_area_value, effective_start, effective_end, row_index)
-      carrier_name = issuer_products.first.issuer_profile.legal_name
-      ra_val = rating_area_value.gsub("R-MA00", "Rating Area ")
+    def write_sheet2_age_rows(worksheet, premium_tables, row_context, row_index)
+      issuer_hios_id = row_context[:issuer_hios_id]
+      carrier_name = row_context[:carrier_name]
+      ra_val = row_context[:rating_area_value].gsub("R-MA00", "Rating Area ")
+      effective_start = row_context[:effective_start]
+      effective_end = row_context[:effective_end]
       (14..64).each do |value|
         age = case value
               when 14 then "0-14"

--- a/app/models/services/plan_validation_report.rb
+++ b/app/models/services/plan_validation_report.rb
@@ -33,7 +33,13 @@ module Services
     end
 
     def issuer_hios_ids
-      profiles.flat_map(&:issuer_hios_ids).map(&:to_i)
+      profiles.flat_map { |profile| issuer_hios_ids_for(profile) }.map(&:to_i)
+    end
+
+    # Issuer HIOS ids for a profile, excluding any that have no products loaded for
+    # the active year (e.g. legacy off-exchange ids like Fallon's 52710).
+    def issuer_hios_ids_for(profile)
+      profile.issuer_hios_ids.map(&:to_s).select { |hios_id| products(active_year).where(hios_id: /\A#{hios_id}/i).present? }
     end
 
     def profiles
@@ -143,7 +149,7 @@ module Services
       profiles.each do |profile|
         carrier_name = profile.abbrev
         profile_id = profile.id.to_s
-        profile.issuer_hios_ids.each do |issuer_hios_id|
+        issuer_hios_ids_for(profile).each do |issuer_hios_id|
           group_sizes = BenefitMarkets::Products::ActuarialFactors::GroupSizeActuarialFactor.where(active_year: active_year, issuer_profile_id: profile_id)
           group_sizes.each do |group_size|
             group_size_sum = group_size.actuarial_factor_entries.map(&:factor_key).flatten.inject(0) do |sum,i|
@@ -170,7 +176,7 @@ module Services
       profiles.each do |profile|
         carrier_name = profile.abbrev
         profile_id = profile.id.to_s
-        profile.issuer_hios_ids.each do |issuer_hios_id|
+        issuer_hios_ids_for(profile).each do |issuer_hios_id|
           part_rates = ::BenefitMarkets::Products::ActuarialFactors::ParticipationRateActuarialFactor.where(active_year: active_year, issuer_profile_id: profile_id)
           part_rates.each do |part_rate|
             group_size_sum = part_rate.actuarial_factor_entries.map(&:factor_key).flatten.inject(0) do |sum,i|
@@ -197,7 +203,7 @@ module Services
       profiles.each do |profile|
         carrier_name = profile.abbrev
         profile_id = profile.id.to_s
-        profile.issuer_hios_ids.each do |issuer_hios_id|
+        issuer_hios_ids_for(profile).each do |issuer_hios_id|
           sic_codes = ::BenefitMarkets::Products::ActuarialFactors::SicActuarialFactor.where(active_year: active_year, issuer_profile_id: profile_id)
           sic_codes.all.each do |sic_code|
             sic_count = sic_code.actuarial_factor_entries.count

--- a/lib/tasks/cca_plan_validation_report.rake
+++ b/lib/tasks/cca_plan_validation_report.rake
@@ -4,12 +4,24 @@
 # To generate all reports please use this rake command: RAILS_ENV=production bundle exec rake cca_plan_validation:reports active_date="2019-12-01" recipients="abc@example.gov,aba1@example.com"
 namespace :cca_plan_validation do
 
-  desc "reports generation after plan loading"
-  task :reports => :environment do
-    puts "Reports generation started" unless Rails.env.test?
-    active_date = ENV['active_date'].to_date
-    recipients = ENV['recipients']
+  def apply_issuer_hios_scope(report, issuer_hios_id_filter)
+    report.define_singleton_method(:profiles) do
+      BenefitSponsors::Organizations::ExemptOrganization.issuer_profiles
+        .select { |eo| eo.issuer_profile.issuer_hios_ids.any? { |id| id.to_s.start_with?(issuer_hios_id_filter) } }
+        .map(&:profiles).flatten
+    end
+
+    report.define_singleton_method(:products) do |year|
+      ::BenefitMarkets::Products::Product.by_year(year).where(hios_id: /\A#{issuer_hios_id_filter}/)
+    end
+  end
+
+  def run_validation_report(active_date, recipients, issuer_hios_id_filter)
     report = Services::PlanValidationReport.new(active_date)
+    apply_issuer_hios_scope(report, issuer_hios_id_filter)
+
+    puts "Filtering report to issuer_hios_id: #{issuer_hios_id_filter} for active_date: #{active_date}" unless Rails.env.test?
+
     report.sheet1
     report.sheet2
     report.sheet3
@@ -29,5 +41,16 @@ namespace :cca_plan_validation do
       pubber.publish URI.join("file://", file_name)
       UserMailer.generic_plan_validation_report_alert(recipients).deliver_now
     end
+
+    file_name
+  end
+
+  desc "reports generation after plan loading"
+  task :reports => :environment do
+    puts "Reports generation started" unless Rails.env.test?
+    active_date = ENV['active_date'].to_date
+    recipients = ENV['recipients']
+    issuer_hios_id_filter = ENV['issuer_hios_id'] || '88806'
+    run_validation_report(active_date, recipients, issuer_hios_id_filter)
   end
 end

--- a/lib/tasks/cca_plan_validation_report.rake
+++ b/lib/tasks/cca_plan_validation_report.rake
@@ -1,26 +1,39 @@
 # frozen_string_literal: true
 
-# This rake tasks should be run to generate reports after plans loading.
-# To generate all reports please use this rake command: RAILS_ENV=production bundle exec rake cca_plan_validation:reports active_date="2019-12-01" recipients="abc@example.gov,aba1@example.com"
+# Generates the CCA plan-load validation reports, one workbook per carrier, after plans are loaded.
+# RAILS_ENV=production bundle exec rake cca_plan_validation:reports active_date="2026-01-01" recipients="abc@example.gov"
+# Optionally restrict to a single carrier:  issuer_hios_id="88806"
 namespace :cca_plan_validation do
 
-  def apply_issuer_hios_scope(report, issuer_hios_id_filter)
-    report.define_singleton_method(:profiles) do
-      BenefitSponsors::Organizations::ExemptOrganization.issuer_profiles
-        .select { |eo| eo.issuer_profile.issuer_hios_ids.any? { |id| id.to_s.start_with?(issuer_hios_id_filter) } }
-        .map(&:profiles).flatten
-    end
+  def carrier_profiles(issuer_hios_id_filter = nil)
+    profiles = BenefitSponsors::Organizations::ExemptOrganization.issuer_profiles.map(&:profiles).flatten
+    return profiles if issuer_hios_id_filter.blank?
 
-    report.define_singleton_method(:products) do |year|
-      ::BenefitMarkets::Products::Product.by_year(year).where(hios_id: /\A#{issuer_hios_id_filter}/)
+    profiles.select do |profile|
+      profile.issuer_hios_ids.any? { |id| id.to_s.start_with?(issuer_hios_id_filter) }
     end
   end
 
-  def run_validation_report(active_date, recipients, issuer_hios_id_filter)
-    report = Services::PlanValidationReport.new(active_date)
-    apply_issuer_hios_scope(report, issuer_hios_id_filter)
+  def apply_issuer_scope(report, profile, hios_ids)
+    report.define_singleton_method(:profiles) { [profile] }
+    report.define_singleton_method(:products) do |year|
+      BenefitMarkets::Products::Product.by_year(year).where(hios_id: /\A(#{hios_ids.join('|')})/)
+    end
+  end
 
-    puts "Filtering report to issuer_hios_id: #{issuer_hios_id_filter} for active_date: #{active_date}" unless Rails.env.test?
+  # Filesystem-safe, collision-free slug. `abbrev` is free text and not unique, so the
+  # carrier's (product-backed) hios ids are appended to keep each carrier's file distinct.
+  def carrier_slug(profile, hios_ids)
+    [profile.abbrev.presence, *hios_ids].compact.join('_').gsub(/[^A-Za-z0-9]/, '_')
+  end
+
+  def build_carrier_report(active_date, profile)
+    report = Services::PlanValidationReport.new(active_date)
+    hios_ids = report.issuer_hios_ids_for(profile)
+    return if hios_ids.empty?
+
+    puts "Generating plan validation report for carrier: #{carrier_slug(profile, hios_ids)}" unless Rails.env.test?
+    apply_issuer_scope(report, profile, hios_ids)
 
     report.sheet1
     report.sheet2
@@ -33,24 +46,31 @@ namespace :cca_plan_validation do
     report.sheet9
 
     current_date = Date.today.strftime("%Y_%m_%d")
-    file_name = "#{Rails.root}/CCA_PlanLoadValidation_Report_EA_#{current_date}.xlsx"
+    file_name = "#{Rails.root}/CCA_PlanLoadValidation_Report_#{carrier_slug(profile, hios_ids)}_#{current_date}.xlsx"
     report.generate_file(file_name)
+    file_name
+  end
+
+  def run_validation_report(active_date, recipients, issuer_hios_id_filter = nil)
+    generated_files = carrier_profiles(issuer_hios_id_filter).filter_map do |profile|
+      build_carrier_report(active_date, profile)
+    end
 
     if Rails.env.production?
       pubber = Publishers::Legacy::PlanValidationReportPublisher.new
-      pubber.publish URI.join("file://", file_name)
+      generated_files.each { |file_name| pubber.publish URI.join("file://", file_name) }
       UserMailer.generic_plan_validation_report_alert(recipients).deliver_now
     end
 
-    file_name
+    generated_files
   end
 
   desc "reports generation after plan loading"
   task :reports => :environment do
     puts "Reports generation started" unless Rails.env.test?
     active_date = ENV['active_date'].to_date
-    recipients = ENV['recipients']
-    issuer_hios_id_filter = ENV['issuer_hios_id'] || '88806'
+    recipients = ENV.fetch('recipients', nil)
+    issuer_hios_id_filter = ENV.fetch('issuer_hios_id', nil)
     run_validation_report(active_date, recipients, issuer_hios_id_filter)
   end
 end

--- a/spec/lib/tasks/cca_plan_validation_report_spec.rb
+++ b/spec/lib/tasks/cca_plan_validation_report_spec.rb
@@ -7,18 +7,40 @@ require 'rubyXL/convenience_methods'
 
 describe 'reports generation after plan loading', :dbclean => :after_each do
 
-  let(:current_date) {Date.today.strftime("%Y_%m_%d")}
-  let(:file_name) {"#{Rails.root}/CCA_PlanLoadValidation_Report_EA_#{current_date}.xlsx"}
+  let(:current_date) { Date.today.strftime("%Y_%m_%d") }
+  let(:issuer_abbrev) { "TEST" }
+  let(:issuer_hios_id) { "88888" }
+  let(:file_name) { "#{Rails.root}/CCA_PlanLoadValidation_Report_#{issuer_abbrev}_#{issuer_hios_id}_#{current_date}.xlsx" }
 
   before do
     load File.expand_path("#{Rails.root}/lib/tasks/cca_plan_validation_report.rake", __FILE__)
     Rake::Task.define_task(:environment)
-    allow(Date).to receive(:today).and_return Date.new(2001,2,3)
+    allow(Date).to receive(:today).and_return Date.new(2001, 2, 3)
+
+    # Set up test data: create an ExemptOrganization with an IssuerProfile
+    issuer_org = FactoryBot.create(:benefit_sponsors_organizations_exempt_organization, :with_issuer_profile)
+    issuer_profile = issuer_org.issuer_profile
+    issuer_profile.update(abbrev: issuer_abbrev, issuer_hios_ids: [issuer_hios_id])
+
+    # Create a product for 2019 (active year) with the issuer profile
+    start_date = Date.new(2019, 1, 1)
+    end_date = Date.new(2019, 12, 31)
+    application_period = Time.utc(start_date.year, start_date.month, start_date.day)..Time.utc(end_date.year, end_date.month, end_date.day)
+
+    FactoryBot.create(
+      :benefit_markets_products_health_products_health_product,
+      issuer_profile_id: issuer_profile.id,
+      application_period: application_period,
+      benefit_market_kind: :aca_shop,
+      kind: :health,
+      product_package_kinds: [:single_issuer],
+      hios_id: "#{issuer_hios_id}MA0100001-01"
+    )
   end
 
   context 'generation of reports' do
     after :all do
-      File.delete(File.join("#{Rails.root}/", "CCA_PlanLoadValidation_Report_EA_2001_02_03.xlsx")) if File.file?(File.join("#{Rails.root}/", "CCA_PlanLoadValidation_Report_EA_2001_02_03.xlsx"))
+      FileUtils.rm_f(Dir.glob("#{Rails.root}/CCA_PlanLoadValidation_Report_*_2001_02_03.xlsx"))
     end
 
     it 'should generate a xlsx when active date is passed' do
@@ -42,7 +64,7 @@ describe 'reports generation after plan loading', :dbclean => :after_each do
         workbook = RubyXL::Parser.parse(file_name)
         worksheet1 = workbook[1]
         worksheet1.sheet_data[0]
-        expect(worksheet1.sheet_data[0].cells.map(&:value)).to eq ["PlanYearId", "CarrierId", "CarrierName", "RatingArea", "Age(Range)", "IndividualRate"]
+        expect(worksheet1.sheet_data[0].cells.map(&:value)).to eq ["PlanYearId", "CarrierId", "CarrierName", "RatingArea", "Age(Range)", "IndividualRate", "EffectiveDate", "ExpirationDate"]
       end
     end
 

--- a/spec/lib/tasks/cca_plan_validation_report_spec.rb
+++ b/spec/lib/tasks/cca_plan_validation_report_spec.rb
@@ -128,4 +128,140 @@ describe 'reports generation after plan loading', :dbclean => :after_each do
       end
     end
   end
+
+  context 'behavior 1b: hios_id with no products is excluded from filename' do
+    after :all do
+      FileUtils.rm_f(Dir.glob("#{Rails.root}/CCA_PlanLoadValidation_Report_*_2001_02_03.xlsx"))
+    end
+
+    it 'excludes productless hios_id from the carrier slug in filename' do
+      # Setup: issuer_profile already has one hios_id with a product from the before block
+      # Now add a second hios_id with no product
+      issuer_org = FactoryBot.create(:benefit_sponsors_organizations_exempt_organization, :with_issuer_profile)
+      issuer_profile = issuer_org.issuer_profile
+      issuer_profile.update(
+        abbrev: "FALLON",
+        issuer_hios_ids: ["88888", "52710"]
+      )
+
+      # Create product only for 88888, not for 52710
+      start_date = Date.new(2019, 1, 1)
+      end_date = Date.new(2019, 12, 31)
+      application_period = (Time.utc(start_date.year, start_date.month, start_date.day)..
+                            Time.utc(end_date.year, end_date.month, end_date.day))
+
+      FactoryBot.create(
+        :benefit_markets_products_health_products_health_product,
+        issuer_profile_id: issuer_profile.id,
+        application_period: application_period,
+        benefit_market_kind: :aca_shop,
+        kind: :health,
+        product_package_kinds: [:single_issuer],
+        hios_id: "88888MA0100001-01"
+      )
+
+      ClimateControl.modify active_date: "2019-12-01" do
+        Rake::Task["cca_plan_validation:reports"].reenable
+        Rake::Task["cca_plan_validation:reports"].invoke
+      end
+
+      # Assert that the file includes only the productful hios_id (88888), not 52710
+      generated_files = Dir.glob("#{Rails.root}/CCA_PlanLoadValidation_Report_FALLON_*_2001_02_03.xlsx")
+      expect(generated_files).to include(
+        "#{Rails.root}/CCA_PlanLoadValidation_Report_FALLON_88888_2001_02_03.xlsx"
+      )
+      expect(generated_files).not_to include(
+        "#{Rails.root}/CCA_PlanLoadValidation_Report_FALLON_88888_52710_2001_02_03.xlsx"
+      )
+    end
+  end
+
+  context 'behavior 2: separate files per carrier, each scoped to its own data' do
+    after :all do
+      FileUtils.rm_f(Dir.glob("#{Rails.root}/CCA_PlanLoadValidation_Report_*_2001_02_03.xlsx"))
+    end
+
+    it 'generates one file per carrier with distinct slugs' do
+      # Create second carrier
+      second_issuer_org = FactoryBot.create(:benefit_sponsors_organizations_exempt_organization, :with_issuer_profile)
+      second_issuer_profile = second_issuer_org.issuer_profile
+      second_issuer_profile.update(
+        abbrev: "BTWO",
+        issuer_hios_ids: ["99999"]
+      )
+
+      start_date = Date.new(2019, 1, 1)
+      end_date = Date.new(2019, 12, 31)
+      application_period = (Time.utc(start_date.year, start_date.month, start_date.day)..
+                            Time.utc(end_date.year, end_date.month, end_date.day))
+
+      # Create product for second carrier
+      FactoryBot.create(
+        :benefit_markets_products_health_products_health_product,
+        issuer_profile_id: second_issuer_profile.id,
+        application_period: application_period,
+        benefit_market_kind: :aca_shop,
+        kind: :health,
+        product_package_kinds: [:single_issuer],
+        hios_id: "99999MA0100001-01"
+      )
+
+      ClimateControl.modify active_date: "2019-12-01" do
+        Rake::Task["cca_plan_validation:reports"].reenable
+        Rake::Task["cca_plan_validation:reports"].invoke
+      end
+
+      # Assert two distinct files are generated
+      first_carrier_file = "#{Rails.root}/CCA_PlanLoadValidation_Report_TEST_88888_2001_02_03.xlsx"
+      second_carrier_file = "#{Rails.root}/CCA_PlanLoadValidation_Report_BTWO_99999_2001_02_03.xlsx"
+
+      expect(File.exist?(first_carrier_file)).to be true
+      expect(File.exist?(second_carrier_file)).to be true
+    end
+
+    it 'each carrier file contains only that carrier\'s data' do
+      # Create second carrier
+      second_issuer_org = FactoryBot.create(:benefit_sponsors_organizations_exempt_organization, :with_issuer_profile)
+      second_issuer_profile = second_issuer_org.issuer_profile
+      second_issuer_profile.update(
+        abbrev: "ATHREE",
+        issuer_hios_ids: ["77777"]
+      )
+
+      start_date = Date.new(2019, 1, 1)
+      end_date = Date.new(2019, 12, 31)
+      application_period = (Time.utc(start_date.year, start_date.month, start_date.day)..
+                            Time.utc(end_date.year, end_date.month, end_date.day))
+
+      # Create product for second carrier
+      FactoryBot.create(
+        :benefit_markets_products_health_products_health_product,
+        issuer_profile_id: second_issuer_profile.id,
+        application_period: application_period,
+        benefit_market_kind: :aca_shop,
+        kind: :health,
+        product_package_kinds: [:single_issuer],
+        hios_id: "77777MA0100001-01"
+      )
+
+      ClimateControl.modify active_date: "2019-12-01" do
+        Rake::Task["cca_plan_validation:reports"].reenable
+        Rake::Task["cca_plan_validation:reports"].invoke
+      end
+
+      first_carrier_file = "#{Rails.root}/CCA_PlanLoadValidation_Report_TEST_88888_2001_02_03.xlsx"
+      second_carrier_file = "#{Rails.root}/CCA_PlanLoadValidation_Report_ATHREE_77777_2001_02_03.xlsx"
+
+      workbook1 = RubyXL::Parser.parse(first_carrier_file)
+      worksheet1 = workbook1[0]
+      first_carrier_hios_ids = worksheet1.sheet_data[1..].map { |row| row&.cells&.at(1)&.value }.compact.uniq
+
+      workbook2 = RubyXL::Parser.parse(second_carrier_file)
+      worksheet2 = workbook2[0]
+      second_carrier_hios_ids = worksheet2.sheet_data[1..].map { |row| row&.cells&.at(1)&.value }.compact.uniq
+
+      expect(first_carrier_hios_ids).to eq([88888])
+      expect(second_carrier_hios_ids).to eq([77777])
+    end
+  end
 end

--- a/spec/lib/tasks/cca_plan_validation_report_spec.rb
+++ b/spec/lib/tasks/cca_plan_validation_report_spec.rb
@@ -8,260 +8,116 @@ require 'rubyXL/convenience_methods'
 describe 'reports generation after plan loading', :dbclean => :after_each do
 
   let(:current_date) { Date.today.strftime("%Y_%m_%d") }
-  let(:issuer_abbrev) { "TEST" }
-  let(:issuer_hios_id) { "88888" }
-  let(:file_name) { "#{Rails.root}/CCA_PlanLoadValidation_Report_#{issuer_abbrev}_#{issuer_hios_id}_#{current_date}.xlsx" }
+  let(:plan_year_period) { Time.utc(2019, 1, 1)..Time.utc(2019, 12, 31) }
+
+  # Creates an issuer profile (carrier) and, by default, a product for every hios id.
+  # Pass product_hios_ids to give the carrier hios ids that have no products.
+  def create_carrier(abbrev:, hios_ids:, product_hios_ids: hios_ids)
+    profile = FactoryBot.create(:benefit_sponsors_organizations_exempt_organization, :with_issuer_profile).issuer_profile
+    profile.update(abbrev: abbrev, issuer_hios_ids: hios_ids)
+    product_hios_ids.each { |hios_prefix| create_product(profile, hios_prefix) }
+    profile
+  end
+
+  def create_product(profile, hios_prefix)
+    FactoryBot.create(
+      :benefit_markets_products_health_products_health_product,
+      issuer_profile_id: profile.id,
+      application_period: plan_year_period,
+      benefit_market_kind: :aca_shop,
+      kind: :health,
+      product_package_kinds: [:single_issuer],
+      hios_id: "#{hios_prefix}MA0100001-01"
+    )
+  end
+
+  def generate_reports
+    ClimateControl.modify active_date: "2019-12-01" do
+      Rake::Task["cca_plan_validation:reports"].reenable
+      Rake::Task["cca_plan_validation:reports"].invoke
+    end
+  end
+
+  def report_path(slug)
+    "#{Rails.root}/CCA_PlanLoadValidation_Report_#{slug}_#{current_date}.xlsx"
+  end
+
+  # CarrierId (hios id) values found in the data rows of a report's first sheet.
+  def carrier_ids_in(path)
+    RubyXL::Parser.parse(path)[0].sheet_data[1..].map { |row| row&.cells&.at(1)&.value }.compact.uniq
+  end
 
   before do
     load File.expand_path("#{Rails.root}/lib/tasks/cca_plan_validation_report.rake", __FILE__)
     Rake::Task.define_task(:environment)
     allow(Date).to receive(:today).and_return Date.new(2001, 2, 3)
-
-    # Set up test data: create an ExemptOrganization with an IssuerProfile
-    issuer_org = FactoryBot.create(:benefit_sponsors_organizations_exempt_organization, :with_issuer_profile)
-    issuer_profile = issuer_org.issuer_profile
-    issuer_profile.update(abbrev: issuer_abbrev, issuer_hios_ids: [issuer_hios_id])
-
-    # Create a product for 2019 (active year) with the issuer profile
-    start_date = Date.new(2019, 1, 1)
-    end_date = Date.new(2019, 12, 31)
-    application_period = Time.utc(start_date.year, start_date.month, start_date.day)..Time.utc(end_date.year, end_date.month, end_date.day)
-
-    FactoryBot.create(
-      :benefit_markets_products_health_products_health_product,
-      issuer_profile_id: issuer_profile.id,
-      application_period: application_period,
-      benefit_market_kind: :aca_shop,
-      kind: :health,
-      product_package_kinds: [:single_issuer],
-      hios_id: "#{issuer_hios_id}MA0100001-01"
-    )
   end
 
-  context 'generation of reports' do
-    after :all do
-      FileUtils.rm_f(Dir.glob("#{Rails.root}/CCA_PlanLoadValidation_Report_*_2001_02_03.xlsx"))
+  after do
+    FileUtils.rm_f(Dir.glob(report_path("*")))
+  end
+
+  context 'with a single carrier' do
+    let(:file_name) { report_path("TEST_88888") }
+
+    before do
+      create_carrier(abbrev: "TEST", hios_ids: ["88888"])
+      generate_reports
     end
 
-    it 'should generate a xlsx when active date is passed' do
-      ClimateControl.modify active_date: "2019-12-01" do
-        Rake::Task["cca_plan_validation:reports"].invoke
-        expect(File.exist?(file_name)).to be true
-      end
+    it 'generates a workbook for the carrier' do
+      expect(File).to exist(file_name)
     end
 
-    context 'first sheet' do
-      it 'should generate xlsx report with given headers' do
-        workbook = RubyXL::Parser.parse(file_name)
-        worksheet = workbook[0]
-        worksheet.sheet_data[0]
-        expect(worksheet.sheet_data[0].cells.map(&:value)).to eq ["PlanYearId", "CarrierId", "CarrierName", "PlanTypeCode", "Tier", "Count"]
-      end
-    end
+    it 'writes the expected headers on every sheet' do
+      sheet_headers = [
+        ["PlanYearId", "CarrierId", "CarrierName", "PlanTypeCode", "Tier", "Count"],
+        ["PlanYearId", "CarrierId", "CarrierName", "RatingArea", "Age(Range)", "IndividualRate", "EffectiveDate", "ExpirationDate"],
+        ["PlanYearId", "CarrierId", "CarrierName", "ServiceAreaCode", "PlanCount", "County_Count", "Zip_Count"],
+        ["PlanYearId", "CarrierId", "CarrierName", "GroupSizeSum", "GroupSizeFactorSum"],
+        ["PlanYearId", "CarrierId", "CarrierName", "GroupSizeSum", "ParticipationRateSum"],
+        ["PlanYearId", "CarrierId", "CarrierName", "SIC_Count", "SICRateSum"],
+        ["CarrierId", "CarrierName", "ProductModel", "PlanCount"],
+        ["CarrierId", "CarrierName", "HIOS_ID", "Renewal_HIOS_ID"],
+        ["PlanYearId", "CarrierId", "CarrierName", "HIOS_Plan_ID", "SG_ID"]
+      ]
 
-    context 'second sheet' do
-      it 'should generate xlsx report with given headers' do
-        workbook = RubyXL::Parser.parse(file_name)
-        worksheet1 = workbook[1]
-        worksheet1.sheet_data[0]
-        expect(worksheet1.sheet_data[0].cells.map(&:value)).to eq ["PlanYearId", "CarrierId", "CarrierName", "RatingArea", "Age(Range)", "IndividualRate", "EffectiveDate", "ExpirationDate"]
-      end
-    end
-
-    context 'third sheet' do
-      it 'should generate xlsx report with given headers' do
-        workbook = RubyXL::Parser.parse(file_name)
-        worksheet2 = workbook[2]
-        worksheet2.sheet_data[0]
-        expect(worksheet2.sheet_data[0].cells.map(&:value)).to eq ["PlanYearId", "CarrierId", "CarrierName", "ServiceAreaCode", "PlanCount", "County_Count", "Zip_Count"]
-      end
-    end
-
-    context 'fourth sheet' do
-      it 'should generate xlsx report with given headers' do
-        workbook = RubyXL::Parser.parse(file_name)
-        worksheet3 = workbook[3]
-        worksheet3.sheet_data[0]
-        expect(worksheet3.sheet_data[0].cells.map(&:value)).to eq ["PlanYearId", "CarrierId", "CarrierName", "GroupSizeSum", "GroupSizeFactorSum"]
-      end
-    end
-
-    context 'fifth sheet' do
-      it 'should generate xlsx report with given headers' do
-        workbook = RubyXL::Parser.parse(file_name)
-        worksheet4 = workbook[4]
-        worksheet4.sheet_data[0]
-        expect(worksheet4.sheet_data[0].cells.map(&:value)).to eq ["PlanYearId", "CarrierId", "CarrierName", "GroupSizeSum", "ParticipationRateSum"]
-      end
-    end
-    context 'sixth sheet' do
-      it 'should generate xlsx report with given headers' do
-        workbook = RubyXL::Parser.parse(file_name)
-        worksheet5 = workbook[5]
-        worksheet5.sheet_data[0]
-        expect(worksheet5.sheet_data[0].cells.map(&:value)).to eq ["PlanYearId", "CarrierId", "CarrierName", "SIC_Count", "SICRateSum"]
-      end
-    end
-    context 'seventh sheet' do
-      it 'should generate xlsx report with given headers' do
-        workbook = RubyXL::Parser.parse(file_name)
-        worksheet6 = workbook[6]
-        worksheet6.sheet_data[0]
-        expect(worksheet6.sheet_data[0].cells.map(&:value)).to eq ["CarrierId", "CarrierName", "ProductModel", "PlanCount"]
-      end
-    end
-    context 'eighth sheet' do
-      it 'should generate xlsx report with given headers' do
-        workbook = RubyXL::Parser.parse(file_name)
-        worksheet7 = workbook[7]
-        worksheet7.sheet_data[0]
-        expect(worksheet7.sheet_data[0].cells.map(&:value)).to eq ["CarrierId", "CarrierName", "HIOS_ID", "Renewal_HIOS_ID"]
-      end
-    end
-
-    context 'ninth sheet' do
-      it 'should generate xlsx report with given headers' do
-        workbook = RubyXL::Parser.parse(file_name)
-        worksheet8 = workbook[8]
-        worksheet8.sheet_data[0]
-        expect(worksheet8.sheet_data[0].cells.map(&:value)).to eq ["PlanYearId", "CarrierId", "CarrierName", "HIOS_Plan_ID", "SG_ID"]
+      workbook = RubyXL::Parser.parse(file_name)
+      aggregate_failures do
+        sheet_headers.each_with_index do |headers, index|
+          expect(workbook[index].sheet_data[0].cells.map(&:value)).to eq(headers)
+        end
       end
     end
   end
 
-  context 'behavior 1b: hios_id with no products is excluded from filename' do
-    after :all do
-      FileUtils.rm_f(Dir.glob("#{Rails.root}/CCA_PlanLoadValidation_Report_*_2001_02_03.xlsx"))
+  context 'when a carrier has a hios id with no products' do
+    before do
+      create_carrier(abbrev: "FALLON", hios_ids: ["88888", "52710"], product_hios_ids: ["88888"])
+      generate_reports
     end
 
-    it 'excludes productless hios_id from the carrier slug in filename' do
-      # Setup: issuer_profile already has one hios_id with a product from the before block
-      # Now add a second hios_id with no product
-      issuer_org = FactoryBot.create(:benefit_sponsors_organizations_exempt_organization, :with_issuer_profile)
-      issuer_profile = issuer_org.issuer_profile
-      issuer_profile.update(
-        abbrev: "FALLON",
-        issuer_hios_ids: ["88888", "52710"]
-      )
-
-      # Create product only for 88888, not for 52710
-      start_date = Date.new(2019, 1, 1)
-      end_date = Date.new(2019, 12, 31)
-      application_period = (Time.utc(start_date.year, start_date.month, start_date.day)..
-                            Time.utc(end_date.year, end_date.month, end_date.day))
-
-      FactoryBot.create(
-        :benefit_markets_products_health_products_health_product,
-        issuer_profile_id: issuer_profile.id,
-        application_period: application_period,
-        benefit_market_kind: :aca_shop,
-        kind: :health,
-        product_package_kinds: [:single_issuer],
-        hios_id: "88888MA0100001-01"
-      )
-
-      ClimateControl.modify active_date: "2019-12-01" do
-        Rake::Task["cca_plan_validation:reports"].reenable
-        Rake::Task["cca_plan_validation:reports"].invoke
-      end
-
-      # Assert that the file includes only the productful hios_id (88888), not 52710
-      generated_files = Dir.glob("#{Rails.root}/CCA_PlanLoadValidation_Report_FALLON_*_2001_02_03.xlsx")
-      expect(generated_files).to include(
-        "#{Rails.root}/CCA_PlanLoadValidation_Report_FALLON_88888_2001_02_03.xlsx"
-      )
-      expect(generated_files).not_to include(
-        "#{Rails.root}/CCA_PlanLoadValidation_Report_FALLON_88888_52710_2001_02_03.xlsx"
-      )
+    it 'omits the productless hios id from the filename' do
+      expect(File).to exist(report_path("FALLON_88888"))
+      expect(File).not_to exist(report_path("FALLON_88888_52710"))
     end
   end
 
-  context 'behavior 2: separate files per carrier, each scoped to its own data' do
-    after :all do
-      FileUtils.rm_f(Dir.glob("#{Rails.root}/CCA_PlanLoadValidation_Report_*_2001_02_03.xlsx"))
+  context 'with multiple carriers' do
+    before do
+      create_carrier(abbrev: "TEST", hios_ids: ["88888"])
+      create_carrier(abbrev: "BTWO", hios_ids: ["99999"])
+      generate_reports
     end
 
-    it 'generates one file per carrier with distinct slugs' do
-      # Create second carrier
-      second_issuer_org = FactoryBot.create(:benefit_sponsors_organizations_exempt_organization, :with_issuer_profile)
-      second_issuer_profile = second_issuer_org.issuer_profile
-      second_issuer_profile.update(
-        abbrev: "BTWO",
-        issuer_hios_ids: ["99999"]
-      )
-
-      start_date = Date.new(2019, 1, 1)
-      end_date = Date.new(2019, 12, 31)
-      application_period = (Time.utc(start_date.year, start_date.month, start_date.day)..
-                            Time.utc(end_date.year, end_date.month, end_date.day))
-
-      # Create product for second carrier
-      FactoryBot.create(
-        :benefit_markets_products_health_products_health_product,
-        issuer_profile_id: second_issuer_profile.id,
-        application_period: application_period,
-        benefit_market_kind: :aca_shop,
-        kind: :health,
-        product_package_kinds: [:single_issuer],
-        hios_id: "99999MA0100001-01"
-      )
-
-      ClimateControl.modify active_date: "2019-12-01" do
-        Rake::Task["cca_plan_validation:reports"].reenable
-        Rake::Task["cca_plan_validation:reports"].invoke
-      end
-
-      # Assert two distinct files are generated
-      first_carrier_file = "#{Rails.root}/CCA_PlanLoadValidation_Report_TEST_88888_2001_02_03.xlsx"
-      second_carrier_file = "#{Rails.root}/CCA_PlanLoadValidation_Report_BTWO_99999_2001_02_03.xlsx"
-
-      expect(File.exist?(first_carrier_file)).to be true
-      expect(File.exist?(second_carrier_file)).to be true
+    it 'generates one file per carrier' do
+      expect(File).to exist(report_path("TEST_88888"))
+      expect(File).to exist(report_path("BTWO_99999"))
     end
 
-    it 'each carrier file contains only that carrier\'s data' do
-      # Create second carrier
-      second_issuer_org = FactoryBot.create(:benefit_sponsors_organizations_exempt_organization, :with_issuer_profile)
-      second_issuer_profile = second_issuer_org.issuer_profile
-      second_issuer_profile.update(
-        abbrev: "ATHREE",
-        issuer_hios_ids: ["77777"]
-      )
-
-      start_date = Date.new(2019, 1, 1)
-      end_date = Date.new(2019, 12, 31)
-      application_period = (Time.utc(start_date.year, start_date.month, start_date.day)..
-                            Time.utc(end_date.year, end_date.month, end_date.day))
-
-      # Create product for second carrier
-      FactoryBot.create(
-        :benefit_markets_products_health_products_health_product,
-        issuer_profile_id: second_issuer_profile.id,
-        application_period: application_period,
-        benefit_market_kind: :aca_shop,
-        kind: :health,
-        product_package_kinds: [:single_issuer],
-        hios_id: "77777MA0100001-01"
-      )
-
-      ClimateControl.modify active_date: "2019-12-01" do
-        Rake::Task["cca_plan_validation:reports"].reenable
-        Rake::Task["cca_plan_validation:reports"].invoke
-      end
-
-      first_carrier_file = "#{Rails.root}/CCA_PlanLoadValidation_Report_TEST_88888_2001_02_03.xlsx"
-      second_carrier_file = "#{Rails.root}/CCA_PlanLoadValidation_Report_ATHREE_77777_2001_02_03.xlsx"
-
-      workbook1 = RubyXL::Parser.parse(first_carrier_file)
-      worksheet1 = workbook1[0]
-      first_carrier_hios_ids = worksheet1.sheet_data[1..].map { |row| row&.cells&.at(1)&.value }.compact.uniq
-
-      workbook2 = RubyXL::Parser.parse(second_carrier_file)
-      worksheet2 = workbook2[0]
-      second_carrier_hios_ids = worksheet2.sheet_data[1..].map { |row| row&.cells&.at(1)&.value }.compact.uniq
-
-      expect(first_carrier_hios_ids).to eq([88888])
-      expect(second_carrier_hios_ids).to eq([77777])
+    it 'scopes each workbook to only that carrier data' do
+      expect(carrier_ids_in(report_path("TEST_88888"))).to eq([88888])
+      expect(carrier_ids_in(report_path("BTWO_99999"))).to eq([99999])
     end
   end
 end

--- a/spec/models/services/plan_validation_report_spec.rb
+++ b/spec/models/services/plan_validation_report_spec.rb
@@ -3,109 +3,51 @@
 require 'rails_helper'
 
 describe Services::PlanValidationReport, :dbclean => :after_each do
-  let(:active_date) { Date.new(2019, 12, 1) }
-  let(:report) { Services::PlanValidationReport.new(active_date) }
-  let(:start_date) { Date.new(2019, 1, 1) }
-  let(:end_date) { Date.new(2019, 12, 31) }
-  let(:application_period) do
-    (Time.utc(start_date.year, start_date.month, start_date.day)..
-      Time.utc(end_date.year, end_date.month, end_date.day))
+  let(:report) { described_class.new(Date.new(2019, 12, 1)) }
+  let(:plan_year_period) { Time.utc(2019, 1, 1)..Time.utc(2019, 12, 31) }
+  let(:issuer_profile) do
+    profile = FactoryBot.create(:benefit_sponsors_organizations_exempt_organization, :with_issuer_profile).issuer_profile
+    profile.update(abbrev: "TEST", issuer_hios_ids: ["88888", "52710"])
+    profile
+  end
+
+  def create_product(hios_prefix)
+    FactoryBot.create(
+      :benefit_markets_products_health_products_health_product,
+      issuer_profile_id: issuer_profile.id,
+      application_period: plan_year_period,
+      benefit_market_kind: :aca_shop,
+      kind: :health,
+      product_package_kinds: [:single_issuer],
+      hios_id: "#{hios_prefix}MA0100001-01"
+    )
   end
 
   describe '#issuer_hios_ids_for' do
-    context 'when issuer profile has multiple hios ids and only one has products' do
-      let(:issuer_org) do
-        FactoryBot.create(:benefit_sponsors_organizations_exempt_organization, :with_issuer_profile)
-      end
-      let(:issuer_profile) { issuer_org.issuer_profile }
+    subject { report.issuer_hios_ids_for(issuer_profile) }
 
-      before do
-        issuer_profile.update(
-          abbrev: "TEST",
-          issuer_hios_ids: ["88888", "52710"]
-        )
+    context 'when only some hios ids have products for the active year' do
+      before { create_product("88888") }
 
-        # Create product for hios_id 88888 only
-        FactoryBot.create(
-          :benefit_markets_products_health_products_health_product,
-          issuer_profile_id: issuer_profile.id,
-          application_period: application_period,
-          benefit_market_kind: :aca_shop,
-          kind: :health,
-          product_package_kinds: [:single_issuer],
-          hios_id: "88888MA0100001-01"
-        )
-      end
-
-      it 'excludes hios_ids without products for the active year' do
-        hios_ids = report.issuer_hios_ids_for(issuer_profile)
-        expect(hios_ids).to eq(["88888"])
-      end
-
-      it 'returns hios_ids as strings' do
-        hios_ids = report.issuer_hios_ids_for(issuer_profile)
-        expect(hios_ids).to all(be_a(String))
+      it 'returns only the hios ids that have products, as strings' do
+        expect(subject).to eq(["88888"])
       end
     end
 
-    context 'when issuer profile has multiple hios ids with products for both' do
-      let(:issuer_org) do
-        FactoryBot.create(:benefit_sponsors_organizations_exempt_organization, :with_issuer_profile)
-      end
-      let(:issuer_profile) { issuer_org.issuer_profile }
-
+    context 'when all hios ids have products for the active year' do
       before do
-        issuer_profile.update(
-          abbrev: "TEST",
-          issuer_hios_ids: ["88888", "52710"]
-        )
-
-        # Create product for hios_id 88888
-        FactoryBot.create(
-          :benefit_markets_products_health_products_health_product,
-          issuer_profile_id: issuer_profile.id,
-          application_period: application_period,
-          benefit_market_kind: :aca_shop,
-          kind: :health,
-          product_package_kinds: [:single_issuer],
-          hios_id: "88888MA0100001-01"
-        )
-
-        # Create product for hios_id 52710
-        FactoryBot.create(
-          :benefit_markets_products_health_products_health_product,
-          issuer_profile_id: issuer_profile.id,
-          application_period: application_period,
-          benefit_market_kind: :aca_shop,
-          kind: :health,
-          product_package_kinds: [:single_issuer],
-          hios_id: "52710MA0100001-01"
-        )
+        create_product("88888")
+        create_product("52710")
       end
 
-      it 'includes all hios_ids that have products for the active year' do
-        hios_ids = report.issuer_hios_ids_for(issuer_profile)
-        expect(hios_ids).to contain_exactly("88888", "52710")
+      it 'returns every hios id' do
+        expect(subject).to contain_exactly("88888", "52710")
       end
     end
 
-    context 'when issuer profile has no products for the active year' do
-      let(:issuer_org) do
-        FactoryBot.create(:benefit_sponsors_organizations_exempt_organization, :with_issuer_profile)
-      end
-      let(:issuer_profile) { issuer_org.issuer_profile }
-
-      before do
-        issuer_profile.update(
-          abbrev: "TEST",
-          issuer_hios_ids: ["88888", "52710"]
-        )
-        # Do not create any products
-      end
-
-      it 'returns empty array' do
-        hios_ids = report.issuer_hios_ids_for(issuer_profile)
-        expect(hios_ids).to eq([])
+    context 'when no hios ids have products for the active year' do
+      it 'returns an empty array' do
+        expect(subject).to eq([])
       end
     end
   end

--- a/spec/models/services/plan_validation_report_spec.rb
+++ b/spec/models/services/plan_validation_report_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Services::PlanValidationReport, :dbclean => :after_each do
+  let(:active_date) { Date.new(2019, 12, 1) }
+  let(:report) { Services::PlanValidationReport.new(active_date) }
+  let(:start_date) { Date.new(2019, 1, 1) }
+  let(:end_date) { Date.new(2019, 12, 31) }
+  let(:application_period) do
+    (Time.utc(start_date.year, start_date.month, start_date.day)..
+      Time.utc(end_date.year, end_date.month, end_date.day))
+  end
+
+  describe '#issuer_hios_ids_for' do
+    context 'when issuer profile has multiple hios ids and only one has products' do
+      let(:issuer_org) do
+        FactoryBot.create(:benefit_sponsors_organizations_exempt_organization, :with_issuer_profile)
+      end
+      let(:issuer_profile) { issuer_org.issuer_profile }
+
+      before do
+        issuer_profile.update(
+          abbrev: "TEST",
+          issuer_hios_ids: ["88888", "52710"]
+        )
+
+        # Create product for hios_id 88888 only
+        FactoryBot.create(
+          :benefit_markets_products_health_products_health_product,
+          issuer_profile_id: issuer_profile.id,
+          application_period: application_period,
+          benefit_market_kind: :aca_shop,
+          kind: :health,
+          product_package_kinds: [:single_issuer],
+          hios_id: "88888MA0100001-01"
+        )
+      end
+
+      it 'excludes hios_ids without products for the active year' do
+        hios_ids = report.issuer_hios_ids_for(issuer_profile)
+        expect(hios_ids).to eq(["88888"])
+      end
+
+      it 'returns hios_ids as strings' do
+        hios_ids = report.issuer_hios_ids_for(issuer_profile)
+        expect(hios_ids).to all(be_a(String))
+      end
+    end
+
+    context 'when issuer profile has multiple hios ids with products for both' do
+      let(:issuer_org) do
+        FactoryBot.create(:benefit_sponsors_organizations_exempt_organization, :with_issuer_profile)
+      end
+      let(:issuer_profile) { issuer_org.issuer_profile }
+
+      before do
+        issuer_profile.update(
+          abbrev: "TEST",
+          issuer_hios_ids: ["88888", "52710"]
+        )
+
+        # Create product for hios_id 88888
+        FactoryBot.create(
+          :benefit_markets_products_health_products_health_product,
+          issuer_profile_id: issuer_profile.id,
+          application_period: application_period,
+          benefit_market_kind: :aca_shop,
+          kind: :health,
+          product_package_kinds: [:single_issuer],
+          hios_id: "88888MA0100001-01"
+        )
+
+        # Create product for hios_id 52710
+        FactoryBot.create(
+          :benefit_markets_products_health_products_health_product,
+          issuer_profile_id: issuer_profile.id,
+          application_period: application_period,
+          benefit_market_kind: :aca_shop,
+          kind: :health,
+          product_package_kinds: [:single_issuer],
+          hios_id: "52710MA0100001-01"
+        )
+      end
+
+      it 'includes all hios_ids that have products for the active year' do
+        hios_ids = report.issuer_hios_ids_for(issuer_profile)
+        expect(hios_ids).to contain_exactly("88888", "52710")
+      end
+    end
+
+    context 'when issuer profile has no products for the active year' do
+      let(:issuer_org) do
+        FactoryBot.create(:benefit_sponsors_organizations_exempt_organization, :with_issuer_profile)
+      end
+      let(:issuer_profile) { issuer_org.issuer_profile }
+
+      before do
+        issuer_profile.update(
+          abbrev: "TEST",
+          issuer_hios_ids: ["88888", "52710"]
+        )
+        # Do not create any products
+      end
+
+      it 'returns empty array' do
+        hios_ids = report.issuer_hios_ids_for(issuer_profile)
+        expect(hios_ids).to eq([])
+      end
+    end
+  end
+end


### PR DESCRIPTION
**ClickUp:** [CCA Rates Validation Reports for all Carriers and all Quarters](https://app.clickup.com/t/9011313074/868k6tdb4)

## Summary

Updates the CCA Plan Validation Report so that:

1. **Effective/expiration dates on Sheet 2** — adds `EffectiveDate` and `ExpirationDate` columns and iterates all rate periods (was on the branch already).
2. **One report workbook per carrier** — instead of a single combined report, the rake task now generates a separate `CCA_PlanLoadValidation_Report_<ABBREV>_<HIOS>_<date>.xlsx` for each MA carrier (health and dental), each containing only that carrier's data across all 9 sheets.
3. **Off-exchange / dead HIOS ids are dropped** — any issuer HIOS id that has no products loaded for the active year is suppressed everywhere it would otherwise appear. This removes Fallon's legacy off-exchange id `52710` (which has no current-year products) from the Fallon report, per stakeholder request, without hardcoding it.

### Why `52710` was appearing
`52710` is a hardcoded second element of Fallon's `issuer_profile.issuer_hios_ids` array (`["88806", "52710"]`), seeded in `load_issuer_profiles.rb` and `carriers_seed_ma.rb`. The report blindly enumerated every entry of that array, and Sheets 4/5/6 iterated `profile.issuer_hios_ids` directly — so the legacy off-exchange id surfaced even though no current-year products use it. Filtering by product existence resolves this generally.

## Changes
- `app/models/services/plan_validation_report.rb`
  - `issuer_hios_ids` now returns only ids with products for the active year, via a new public `issuer_hios_ids_for(profile)` helper.
  - Sheets 4/5/6 iterate `issuer_hios_ids_for(profile)` so dead/off-exchange ids don't surface there.
- `lib/tasks/cca_plan_validation_report.rake`
  - Loops every carrier and generates one workbook each (scoped via `define_singleton_method` on `profiles`/`products`).
  - Optional `issuer_hios_id` env var now restricts to a single carrier (no longer defaults to `88806`).
  - Filenames include the carrier's HIOS ids to avoid collisions on shared/blank abbreviations.
- `spec/lib/tasks/cca_plan_validation_report_spec.rb`
  - Sets up an issuer profile + product so a per-carrier report is generated; updated Sheet 2 header assertion (now includes `EffectiveDate`/`ExpirationDate`) and the per-carrier filename expectation.

## How to run
```bash
RAILS_ENV=production bundle exec rake cca_plan_validation:reports active_date="2026-01-01" recipients="abc@example.gov"
# Optionally restrict to one carrier:
RAILS_ENV=production bundle exec rake cca_plan_validation:reports active_date="2026-01-01" recipients="abc@example.gov" issuer_hios_id="88806"
```

## Testing
- `bundle exec rspec spec/lib/tasks/cca_plan_validation_report_spec.rb` → 10 examples, 0 failures
- `bundle exec rubocop` clean on all changed lines
