### PR TITLE
Upgrade net-ssh/net-sftp for OpenSSL 3 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,8 +157,8 @@ PATH
     transport_gateway (0.0.1)
       aws-sdk (~> 3.2)
       net-imap (>= 0.4.20)
-      net-sftp (~> 2.1, >= 2.1.2)
-      net-ssh (= 4.2.0)
+      net-sftp (~> 4.0)
+      net-ssh (~> 7.3)
       rack (>= 2.2.14)
       rails (~> 8.1, >= 8.1.2)
 
@@ -2206,11 +2206,11 @@ GEM
       timeout
     net-scp (4.0.0)
       net-ssh (>= 2.6.5, < 8.0.0)
-    net-sftp (2.1.2)
-      net-ssh (>= 2.6.5)
+    net-sftp (4.0.0)
+      net-ssh (>= 5.0.0, < 8.0.0)
     net-smtp (0.5.1)
       net-protocol
-    net-ssh (4.2.0)
+    net-ssh (7.3.3)
     newrelic_rpm (9.12.0)
     next_rails (1.4.5)
       rainbow (>= 3)

--- a/components/transport_gateway/transport_gateway.gemspec
+++ b/components/transport_gateway/transport_gateway.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
 
   s.add_dependency 'rails', '~> 8.1', '>= 8.1.2'
-  s.add_dependency 'net-sftp', '~> 2.1', '>= 2.1.2'
-  s.add_dependency 'net-ssh', '4.2.0'
+  s.add_dependency 'net-sftp', '~> 4.0'
+  s.add_dependency 'net-ssh', '~> 7.3'
   s.add_dependency 'aws-sdk', '~> 3.2'
   s.add_dependency 'rack', '>= 2.2.14'
   s.add_dependency 'net-imap',  '>= 0.4.20'


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/health-connector/enroll/blob/master/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Inert code (no impact until run, e.g. data fix or migration, manually triggered bulk process, etc.)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Dependency updates (e.g., add a new gem or update to a version)
- [ ] Release (Prepares code for a release, e.g., version bumps, changelog updates, tagging, deployment scripts)

# What is the ticket # detailing the issue?

Ticket: https://dchbx.atlassian.net/browse/CCAOMDEV-55
https://app.clickup.com/t/9011313074/868k6u1rf

# A brief description of the changes

Current behavior:
Transport gateway SFTP publishing (e.g. the employer roster report) fails under OpenSSL 3 / the `openssl` 4.0.0 gem with `OpenSSL::PKey::DH.new cannot be called without arguments; pkeys are immutable with OpenSSL 3.0 (ArgumentError)`. The error originates in `net-ssh` 4.2.0's Diffie-Hellman key exchange, reached via `SftpAdapter#send_message` -> `Net::SFTP.start`. This is why reports currently run on a downgraded Ruby/Debian branch.

New behavior:
Upgrades `net-ssh` `(4.2.0 -> ~> 7.3)` and `net-sftp` `(~> 2.1 -> ~> 4.0)` in `transport_gateway.gemspec`. net-ssh added OpenSSL 3 support in 7.0 and now constructs DH params immutably; net-sftp 2.x is incompatible with net-ssh 5+, so both are bumped together. The adapter API surface and connection options used are unchanged across these versions.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: n/a


# Additional Context
Include any additional context that may be relevant to the peer review process.
